### PR TITLE
Install systemd file before starting

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -11,14 +11,13 @@ class confluence::service(
   file { $service_file_location:
     content => template($service_file_template),
     mode    => '0755',
-    before  => Service[confluence],
   }
 
   if $confluence::manage_service {
     service { 'confluence':
       ensure  => 'running',
       enable  => true,
-      require => Class['confluence::config'],
+      require => [ Class['confluence::config'], File[$service_file_location], ],
     }
   }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -11,6 +11,7 @@ class confluence::service(
   file { $service_file_location:
     content => template($service_file_template),
     mode    => '0755',
+    before  => Service[confluence],
   }
 
   if $confluence::manage_service {


### PR DESCRIPTION
We need to specified that the systemd file is installed before trying to manage the service. So a little fix that can help others have a very smooth deployment.