### PR TITLE
Deprecate the downloadURL parameter

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -97,7 +97,7 @@ confluence::tomcat_port:    '8090'
 confluence::jvm_xms:        '4G'
 confluence::jvm_xmx:        '8G'
 confluence::jvm_permgen:    '512m'
-confluence::downloadURL:    'http://webserver.example.co.za/pub/software/development-tools/atlassian'
+confluence::download_url:    'http://webserver.example.co.za/pub/software/development-tools/atlassian'
 confluence::tomcat_proxy:
   scheme:    'https'
   proxyName: 'webvip.example.co.za'
@@ -177,7 +177,7 @@ Any additional tomcat params for server.xml. Takes same format as `tomcat_proxy`
 
 #####`manage_server_xml`
 Should we use augeas to manage server.xml or a template file. Defaults to 'augues'. Operating systems that do not have a support version of Augeas such as Ubuntu 12.04 can use 'template'.
-#####`downloadURL`
+#####`download_url`
 Default: 'http://www.atlassian.com/software/confluence/downloads/binary/'
 #####`manage_service`
 Should puppet manage this service? Default: true

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,7 +25,8 @@ class confluence (
   $shell        = '/bin/true',
 
   # Misc Settings
-  $downloadURL  = 'http://www.atlassian.com/software/confluence/downloads/binary',
+  $download_url  = 'http://www.atlassian.com/software/confluence/downloads/binary',
+  $downloadURL   = undef,
 
   # Choose whether to use nanliu-staging, or mkrakowitzer-deploy
   # Defaults to nanliu-staging as it is puppetlabs approved.
@@ -55,6 +56,18 @@ class confluence (
   # This required for upgrades
   $facts_ensure = 'present',
 ) {
+
+  if $downloadURL {
+    warning("${module_name}: The use of downloadURL is deprecated. Use download_url instead.")
+    $real_download_url = $downloadURL
+  } else {
+    $real_download_url = $download_url
+  }
+
+  if $downloadURL and $download_url {
+    fail ("${module_name}: You have specified both downloadURL and download_url. Use download_url only.")
+  }
+
   validate_re($version, '^(?:(\d+)\.)?(?:(\d+)\.)?(\*|\d+)(|[a-z])$')
   validate_absolute_path($installdir)
   validate_absolute_path($homedir)

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -44,7 +44,7 @@ class confluence::install {
     }
 
     staging::file { $file:
-      source  => "${confluence::downloadURL}/${file}",
+      source  => "${confluence::real_download_url}/${file}",
       timeout => 1800,
     } ->
 
@@ -68,7 +68,7 @@ class confluence::install {
 
     deploy::file { $file:
       target          => $confluence::webappdir,
-      url             => $confluence::downloadURL,
+      url             => $confluence::real_download_url,
       strip           => true,
       download_timout => 1800,
       owner           => $confluence::user,

--- a/spec/acceptance/1_default_parameters_spec.rb
+++ b/spec/acceptance/1_default_parameters_spec.rb
@@ -37,7 +37,7 @@ describe 'confluence', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily'
       } ->
       class { 'confluence':
         version             => '5.5.6',
-        downloadURL         => #{download_url},
+        download_url        => #{download_url},
         javahome            => $jh,
       }
     EOS

--- a/spec/acceptance/2_default_parameters_upgrade_spec.rb
+++ b/spec/acceptance/2_default_parameters_upgrade_spec.rb
@@ -30,7 +30,7 @@ describe 'confluence', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily'
       }
       class { 'confluence':
         version             => '5.7',
-        downloadURL         => #{download_url},
+        download_url        => #{download_url},
         javahome            => $jh,
       }
     EOS

--- a/spec/acceptance/3_custom_parameters_spec.rb
+++ b/spec/acceptance/3_custom_parameters_spec.rb
@@ -30,7 +30,7 @@ describe 'confluence', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily'
       }
       class { 'confluence':
         version             => '5.7',
-        downloadURL         => #{download_url},
+        download_url        => #{download_url},
         javahome            => $jh,
         tomcat_port         => '8091',
         tomcat_max_threads  => 999,

--- a/spec/classes/confluence_install_deploy_spec.rb
+++ b/spec/classes/confluence_install_deploy_spec.rb
@@ -12,7 +12,7 @@ describe 'confluence' do
         :homedir           => '/home/confluence',
         :format            => 'tar.gz',
         :product           => 'confluence',
-        :downloadURL       => 'http://www.atlassian.com/software/confluence/downloads/binary/',
+        :download_url      => 'http://www.atlassian.com/software/confluence/downloads/binary/',
 	:staging_or_deploy => 'deploy',
         }}
       it { should contain_group('confluence') }
@@ -42,7 +42,7 @@ describe 'confluence' do
         :uid               => 333,
         :gid               => 444,
         :shell             => '/bin/bash',
-        :downloadURL       => 'http://downloads.atlassian.com/',
+        :download_url      => 'http://downloads.atlassian.com/',
         :staging_or_deploy => 'deploy',
       }}
       it { should contain_user('foo').with({

--- a/spec/classes/confluence_install_staging_spec.rb
+++ b/spec/classes/confluence_install_staging_spec.rb
@@ -53,7 +53,7 @@ describe 'confluence' do
         :uid               => 333,
         :gid               => 444,
         :shell             => '/bin/bash',
-        :downloadURL       => 'http://downloads.atlassian.com',
+        :download_url      => 'http://downloads.atlassian.com',
       }}
 
       it { should contain_user('foo').with({


### PR DESCRIPTION
Add download_url variable as a future replacement for downloadURL in the next major version bump