### PR TITLE
centos 7 service template fixes

### DIFF
--- a/templates/confluence.service.erb
+++ b/templates/confluence.service.erb
@@ -4,7 +4,8 @@ After=network.target
 
 [Service]
 Type=forking
-User=confluence
+User=<%= scope.lookupvar('confluence::user') %>
+Environment="JAVA_HOME=<%= scope.lookupvar('confluence::javahome') %>"
 ExecStart=<%= scope.lookupvar('confluence::webappdir') %>/bin/start-confluence.sh
 ExecStop=<%= scope.lookupvar('confluence::webappdir') %>/bin/stop-confluence.sh
 


### PR DESCRIPTION
* use $confluence::user param instead of hardcoding "User=confluence"
* set JAVA_HOME for systemd based on $confluence::javahome, as done in JIRA and Stash modules