### PR TITLE
Add crowd SSO functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ This puppet module will automatically download the Confluence tar.gz from Atlass
 
 ```puppet
   class { 'confluence':
-    javahome => '/opt/java', 
+    javahome => '/opt/java',
   }
 ```
 
@@ -129,7 +129,7 @@ Specify the java home directory. No assumptions are made re the location of java
 The version of confluence to install. Default: '5.5.6'
 #####`format`
 The format of the file confluence will be installed from. Default: 'tar.gz'
-#####`installdir` 
+#####`installdir`
 The installation directory of the confluence binaries. Default: '/opt/confluence'
 #####`homedir`
 The home directory of confluence. Configuration files are stored here. Default: '/home/confluence'
@@ -158,7 +158,7 @@ The initial memory allocation pool for a Java Virtual Machine. Default: '256m'
 Maximum memory allocation pool for a Java Virtual Machine. Default: '1024m'
 #####`jvm_permgen`
 Increase max permgen size for a Java Virtual Machine. Default: '256m'
-#####`java_opts` 
+#####`java_opts`
 Additional java options can be specified here. Default: ''
 
 ####Tomcat parameters####
@@ -172,6 +172,28 @@ Defaults to '150'
 Defaults to  '100'
 #####`tomcat_extras`
 Any additional tomcat params for server.xml. Takes same format as `tomcat_proxy`. Default: {}
+
+####Crowd single sign on parameters####
+####`enable_sso`
+Enable crowd single sign on configuration as described in https://confluence.atlassian.com/display/CROWD/Integrating+Crowd+with+Atlassian+Confluence#IntegratingCrowdwithAtlassianConfluence-2.2EnableSSOintegrationwithCrowd(Optional)
+####`application_name`
+Set crowd application name
+####`application_password`
+Set crowd application password
+####`application_login_url`
+Set crowd application login url, where to login into crowd (e.g. https://crowd.example.com/console/)
+####`crowd_server_url`
+Set crowd application services url, e.g. https://crowd.example.com/services/
+####`crowd_base_url`
+Set crowd base url, e.g. https://crowd.example.com/
+####`session_isauthenticated`
+Some more crowd.properties for SSO, see atlassian documentation for details
+####`session_tokenkey`
+Some more crowd.properties for SSO, see atlassian documentation for details
+####`session_validationinterval`
+Some more crowd.properties for SSO, see atlassian documentation for details
+####`session_lastvalidation`
+Some more crowd.properties for SSO, see atlassian documentation for details
 
 ####Miscellaneous  parameters####
 
@@ -217,4 +239,3 @@ See CONTRIBUTING.md
 ## Contributors
 
 See CONTRIBUTORS
-

--- a/files/seraph-config_withSSO.xml
+++ b/files/seraph-config_withSSO.xml
@@ -1,0 +1,64 @@
+<security-config>
+    <parameters>
+        <init-param>
+            <param-name>login.url</param-name>
+            <param-value>/login.action?os_destination=${originalurl}</param-value>
+        </init-param>
+        <init-param>
+            <param-name>link.login.url</param-name>
+            <param-value>/login.action</param-value>
+        </init-param>
+        <init-param>
+            <param-name>cookie.encoding</param-name>
+            <param-value>cNf</param-value>
+        </init-param>
+        <init-param>
+            <param-name>login.cookie.key</param-name>
+            <param-value>seraph.confluence</param-value>
+        </init-param>
+
+        <!--only basic authentication available-->
+        <init-param>
+            <param-name>authentication.type</param-name>
+            <param-value>os_authType</param-value>
+        </init-param>
+
+        <!-- Invalidate session on login to prevent session fixation attack -->
+         <init-param>
+            <param-name>invalidate.session.on.login</param-name>
+            <param-value>true</param-value>
+        </init-param>
+        <!-- Add names for session attributes that must not be copied to a new session when the old one gets invalidated.
+          Currently it is empty (i.e. all attributes will be copied). -->
+        <init-param>
+            <param-name>invalidate.session.exclude.list</param-name>
+            <param-value></param-value>
+        </init-param>
+    </parameters>
+
+    <rolemapper class="com.atlassian.confluence.security.ConfluenceRoleMapper"/>
+    <controller class="com.atlassian.confluence.setup.seraph.ConfluenceSecurityController"/>
+
+    <!-- Default Confluence authenticator, which uses the configured user management for authentication. -->
+    <!-- <authenticator class="com.atlassian.confluence.user.ConfluenceAuthenticator"/> -->
+
+    <!-- Custom authenticators appear below. To enable one of them, comment out the default authenticator above and uncomment the one below. -->
+
+    <!-- Authenticator with support for Crowd single-sign on (SSO). -->
+    <authenticator class="com.atlassian.confluence.user.ConfluenceCrowdSSOAuthenticator"/>
+
+    <!-- Specialised version of the default authenticator which adds authenticated users to confluence-users if they aren't already a member. -->
+    <!-- <authenticator class="com.atlassian.confluence.user.ConfluenceGroupJoiningAuthenticator"/> -->
+
+    <services>
+        <service class="com.atlassian.seraph.service.PathService">
+            <init-param>
+                <param-name>config.file</param-name>
+                <param-value>seraph-paths.xml</param-value>
+            </init-param>
+        </service>
+    </services>
+
+    <elevatedsecurityguard class="com.atlassian.confluence.security.seraph.ConfluenceElevatedSecurityGuard"/>
+
+</security-config>

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -54,6 +54,19 @@ class confluence (
   # Enable confluence version fact for running instance
   # This required for upgrades
   $facts_ensure = 'present',
+
+  # Enable SingleSignOn via Crowd
+
+  $enable_sso = false,
+  $application_name = 'crowd',
+  $application_password = '1234',
+  $application_login_url = 'https://crowd.example.com/console/',
+  $crowd_server_url = 'https://crowd.example.com/services/',
+  $crowd_base_url = 'https://crowd.example.com/',
+  $session_isauthenticated = 'session.isauthenticated',
+  $session_tokenkey = 'session.tokenkey',
+  $session_validationinterval = 5,
+  $session_lastvalidation = 'session.lastvalidation',
 ) {
 
   validate_re($version, '^(?:(\d+)\.)?(?:(\d+)\.)?(\*|\d+)(|[a-z])$')
@@ -89,4 +102,9 @@ class confluence (
   class { '::confluence::config': } ~>
   class { '::confluence::service': } ->
   anchor { 'confluence::end': }
+
+  if ($enable_sso) {
+    class { '::confluence::sso':
+    }
+  }
 }

--- a/manifests/sso.pp
+++ b/manifests/sso.pp
@@ -1,0 +1,38 @@
+# == Class: confluence::sso
+#
+# Install confluence SSO via crowd, See README.md for more.
+#
+class confluence::sso(
+  $application_name = $::confluence::application_name,
+  $application_password = $::confluence::application_password,
+  $application_login_url = $::confluence::application_login_url,
+  $crowd_server_url = $::confluence::crowd_server_url,
+  $crowd_base_url = $::confluence::crowd_base_url,
+  $session_isauthenticated = $::confluence::session_isauthenticated,
+  $session_tokenkey = $::confluence::session_tokenkey,
+  $session_validationinterval = $::confluence::session_validationinterval,
+  $session_lastvalidation = $::confluence::session_lastvalidation,
+) {
+
+  validate_re($application_login_url,'^https?\://[a-zA-Z0-9\-\.]+\.[a-zA-Z]{2,3}(/\S*)?$')
+  validate_re($crowd_server_url,'^https?\://[a-zA-Z0-9\-\.]+\.[a-zA-Z]{2,3}(/\S*)?$')
+  validate_re($crowd_base_url,'^https?\://[a-zA-Z0-9\-\.]+\.[a-zA-Z]{2,3}(/\S*)?$')
+
+  file { "${confluence::webappdir}/confluence/WEB-INF/classes/crowd.properties":
+    ensure  => present,
+    content => template('confluence/crowd.properties'),
+    mode    => '0660',
+    owner   => $::confluence::user,
+    group   => $::confluence::group,
+    require => Class['confluence::install'],
+    notify  => Class['confluence::service'],
+  }
+  file { "${confluence::webappdir}/confluence/WEB-INF/classes/seraph-config.xml":
+    source  => 'puppet:///modules/confluence/seraph-config_withSSO.xml',
+    mode    => '0660',
+    owner   => $::confluence::user,
+    group   => $::confluence::group,
+    require => Class['confluence::install'],
+    notify  => Class['confluence::service'],
+  }
+}

--- a/spec/classes/confluence_sso_spec.rb
+++ b/spec/classes/confluence_sso_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper.rb'
+
+describe 'confluence' do
+  describe 'confluence::sso' do
+    context 'default params' do
+      let(:params) {{
+        :javahome   => '/opt/java',
+        :version    => '5.5.6',
+        :enable_sso => true,
+      }}
+      it { should contain_file('/opt/confluence/atlassian-confluence-5.5.6/confluence/WEB-INF/classes/seraph-config.xml') }
+      it { should contain_file('/opt/confluence/atlassian-confluence-5.5.6/confluence/WEB-INF/classes/crowd.properties') }
+    end
+    context 'with param application_name set to appname' do
+      let(:params) {{
+        :javahome         => '/opt/java',
+        :version          => '5.5.6',
+        :enable_sso       => true,
+        :application_name => 'appname',
+      }}
+      it { should contain_file('/opt/confluence/atlassian-confluence-5.5.6/confluence/WEB-INF/classes/crowd.properties')
+        .with_content(/application.name                        appname/)
+      }
+    end
+    context 'with param application_login_url set to ERROR' do
+      let(:params) {{
+        :javahome              => '/opt/java',
+        :version               => '5.5.6',
+        :enable_sso            => true,
+        :application_login_url => 'ERROR',
+      }}
+      it('should fail') {
+        should raise_error(Puppet::Error, /does not match/)
+      }
+    end
+    context 'with non default params' do
+      let(:params) {{
+        :javahome              => '/opt/java',
+        :version               => '5.5.6',
+        :enable_sso            => true,
+        :application_name      => 'app',
+        :application_password  => 'password',
+        :application_login_url => 'https://login.url/',
+        :crowd_server_url      => 'https://crowd.url/',
+        :crowd_base_url        => 'http://crowdbase.url',
+      }}
+      it { should contain_file('/opt/confluence/atlassian-confluence-5.5.6/confluence/WEB-INF/classes/seraph-config.xml') }
+      it { should contain_file('/opt/confluence/atlassian-confluence-5.5.6/confluence/WEB-INF/classes/crowd.properties')
+        .with_content(/application.name                        app/)
+        .with_content(/application.password                    password/)
+        .with_content(%r{application.login.url                   https:\/\/login.url\/})
+        .with_content(%r{crowd.server.url                        https:\/\/crowd.url\/})
+        .with_content(%r{crowd.base.url                          http:\/\/crowdbase.url})
+      }
+    end
+  end
+end

--- a/templates/crowd.properties
+++ b/templates/crowd.properties
@@ -1,0 +1,11 @@
+application.name                        <%= @application_name %>
+application.password                    <%= @application_password %>
+application.login.url                   <%= @application_login_url %>
+
+crowd.server.url                        <%= @crowd_server_url %>
+crowd.base.url                          <%= @crowd_base_url %>
+
+session.isauthenticated                 <%= @session_isauthenticated %>
+session.tokenkey                        <%= @session_tokenkey %>
+session.validationinterval              <%= @session_validationinterval %>
+session.lastvalidation                  <%= @session_lastvalidation %>


### PR DESCRIPTION
Add crowd's single sign on feature to confluence. When using delegated authentication via Atlassian Crowd, you are able to activate this feature according to Atlassian's documentation at https://confluence.atlassian.com/display/CROWD/Integrating+Crowd+with+Atlassian+Confluence#IntegratingCrowdwithAtlassianConfluence-2.2EnableSSOintegrationwithCrowd