### PR TITLE
Added parameter for alternative data dir

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,7 +17,7 @@ class confluence (
   $format       = 'tar.gz',
   $installdir   = '/opt/atlassian/confluence/application',
   $homedir      = '/home/confluence',
-  $data_dir     = undef,
+  $data_dir     = '',
   $user         = 'confluence',
   $group        = 'confluence',
   $uid          = undef,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,7 +17,7 @@ class confluence (
   $format       = 'tar.gz',
   $installdir   = '/opt/atlassian/confluence/application',
   $homedir      = '/home/confluence',
-  $data_dir     = '/opt/atlassian/confluence/data'
+  $data_dir     = undef,
   $user         = 'confluence',
   $group        = 'confluence',
   $uid          = undef,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,8 +15,9 @@ class confluence (
   $version      = '5.7.1',
   $product      = 'confluence',
   $format       = 'tar.gz',
-  $installdir   = '/opt/confluence',
+  $installdir   = '/opt/atlassian/confluence/application',
   $homedir      = '/home/confluence',
+  $data_dir     = '/opt/atlassian/confluence/data'
   $user         = 'confluence',
   $group        = 'confluence',
   $uid          = undef,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,7 +15,7 @@ class confluence (
   $version      = '5.7.1',
   $product      = 'confluence',
   $format       = 'tar.gz',
-  $installdir   = '/opt/atlassian/confluence/application',
+  $installdir   = '/opt/confluence',
   $homedir      = '/home/confluence',
   $data_dir     = '',
   $user         = 'confluence',

--- a/templates/confluence-init.properties.erb
+++ b/templates/confluence-init.properties.erb
@@ -32,4 +32,8 @@
 # specify your directory below (don't forget to remove the '#' in front)
 
 # confluence.home=c:/confluence/data
-confluence.home=<%= scope.lookupvar('confluence::homedir') %>
+<% if scope.lookupvar('confluence::data_dir') -%>
+  confluence.home=<%= scope.lookupvar('confluence::data_dir') %>
+<% else %>
+  confluence.home=<%= scope.lookupvar('confluence::homedir') %>
+<% end %>

--- a/templates/confluence-init.properties.erb
+++ b/templates/confluence-init.properties.erb
@@ -33,7 +33,7 @@
 
 # confluence.home=c:/confluence/data
 <% if scope.lookupvar('confluence::data_dir') -%>
-  confluence.home=<%= scope.lookupvar('confluence::data_dir') %>
+confluence.home=<%= scope.lookupvar('confluence::data_dir') %>
 <% else %>
-  confluence.home=<%= scope.lookupvar('confluence::homedir') %>
+confluence.home=<%= scope.lookupvar('confluence::homedir') %>
 <% end %>


### PR DESCRIPTION
Hi,
modified module to support a data dir which is not the users home e.g: /opt/atlassian/confluence/data. 

Please merge, if tests are ok.

Greets
Taulant
