### PR TITLE
Allow System Group

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -9,6 +9,7 @@ class confluence::install {
   if $::confluence::manage_user {
     group { $confluence::group:
       ensure => present,
+      system => true,
       gid    => $confluence::gid,
     } ->
     user { $confluence::user:

--- a/spec/classes/confluence_install_spec.rb
+++ b/spec/classes/confluence_install_spec.rb
@@ -16,9 +16,14 @@ describe 'confluence' do
         }
       end
 
-      it { is_expected.to contain_group('confluence') }
+      it 'creates a system group' do
+        is_expected.to contain_group('confluence').with_system(true)
+      end
 
-      it { is_expected.to contain_user('confluence').with_shell('/bin/true') }
+      it 'creates a system user with no shell' do
+        is_expected.to contain_user('confluence').with('shell' => '/bin/true',
+                                                       'system' => true)
+      end
 
       it 'deploys confluence 5.5.6 from tar.gz' do
         is_expected.to contain_archive('/tmp/atlassian-confluence-5.5.6.tar.gz').


### PR DESCRIPTION
When managing the confluence user it defaults to a system user, however this doesn't
apply to the group which may be problematic in deployments where other groups are
hard coded to 1000 which has already been taken by confluence.  Make the confluence
group a system account by default, this appears not to alter existing installations.