### PR TITLE
Add support for configuring an AJP connector

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -10,6 +10,7 @@ class confluence::config(
   $tomcat_extras       = $confluence::tomcat_extras,
   $manage_server_xml   = $confluence::manage_server_xml,
   $context_path        = $confluence::context_path,
+  $ajp                 = $confluence::ajp,
 ) {
 
   File {

--- a/spec/classes/confluence_config_spec.rb
+++ b/spec/classes/confluence_config_spec.rb
@@ -67,5 +67,22 @@ describe 'confluence' do
           with_content(%r{Context path="/confluence1"})
       end
     end
+    context 'ajp proxy' do
+      let(:params) do
+        {
+          version: '5.5.6',
+          javahome: '/opt/java',
+          manage_server_xml: 'template',
+          ajp: {
+            'port'     => '8009',
+            'protocol' => 'AJP/1.3'
+          }
+        }
+      end
+      it do
+        is_expected.to contain_file('/opt/confluence/atlassian-confluence-5.5.6/conf/server.xml').
+          with_content(%r{<Connector enableLookups="false" URIEncoding="UTF-8"\s+port = "8009"\s+protocol = "AJP/1.3"\s+/>})
+      end
+    end
   end
 end

--- a/templates/server.xml.erb
+++ b/templates/server.xml.erb
@@ -19,6 +19,14 @@
 <% end -%> 
 />
 
+<% if @ajp and ! @ajp.empty? -%>
+        <Connector enableLookups="false" URIEncoding="UTF-8"
+<%   @ajp.sort.each do |key, value| -%>
+                   <%= key %> = <%= "\"#{value}\"" %>
+<%   end -%>
+        />
+<% end -%>
+
         <Engine name="Standalone" defaultHost="localhost" debug="0">
 
             <Host name="localhost" debug="0" appBase="webapps" unpackWARs="true" autoDeploy="false">


### PR DESCRIPTION
Partially addresses https://github.com/voxpupuli/puppet-confluence/issues/54

