### PR TITLE
Add support for deploying mysql connector

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,6 +25,17 @@ class confluence (
   $manage_user  = true,
   $shell        = '/bin/true',
 
+  # Database settings
+  $db           = 'postgresql',
+
+  # MySQL Connector Settings
+  $mysql_connector_manage  = true,
+  $mysql_connector_version = '5.1.34',
+  $mysql_connector_product = 'mysql-connector-java',
+  $mysql_connector_format  = 'tar.gz',
+  $mysql_connector_install = '/opt/MySQL-connector',
+  $mysql_connector_url     = 'https://dev.mysql.com/get/Downloads/Connector-J',
+
   # Misc Settings
   $download_url = 'http://www.atlassian.com/software/confluence/downloads/binary',
   $checksum     = undef,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -102,4 +102,17 @@ class confluence::install {
     refreshonly => true,
     subscribe   => User[$confluence::user],
   }
+
+  if $confluence::db == 'mysql' and $confluence::mysql_connector_manage {
+    if $confluence::deploy_module == 'archive' {
+      class { '::confluence::mysql_connector':
+        require => Archive["/tmp/${file}"],
+      }
+    } elsif $confluence::deploy_module == 'deploy' {
+      class { '::confluence::mysql_connector':
+        require => Staging::Extract[$file],
+      }
+    }
+    contain ::confluence::mysql_connector
+  }
 }

--- a/manifests/mysql_connector.pp
+++ b/manifests/mysql_connector.pp
@@ -1,0 +1,40 @@
+# Class to install the MySQL Java connector
+class confluence::mysql_connector (
+  $version      = $confluence::mysql_connector_version,
+  $product      = $confluence::mysql_connector_product,
+  $format       = $confluence::mysql_connector_format,
+  $installdir   = $confluence::mysql_connector_install,
+  $download_url = $confluence::mysql_connector_url,
+) {
+
+  require ::staging
+
+  $file = "${product}-${version}.${format}"
+
+  if ! defined(File[$installdir]) {
+    file { $installdir:
+      ensure => 'directory',
+      owner  => root,
+      group  => root,
+      before => Staging::File[$file],
+    }
+  }
+
+  if ! defined(Staging::File[$file]) {
+    staging::file { $file:
+      source  => "${download_url}/${file}",
+      timeout => 300,
+    }
+  }
+
+  staging::extract { "confluence ${file}":
+    source  => $file,
+    target  => $installdir,
+    creates => "${installdir}/${product}-${version}",
+    require => Staging::File[$file],
+  } ->
+  file { "${confluence::webappdir}/lib/mysql-connector-java.jar":
+    ensure => link,
+    target => "${installdir}/${product}-${version}/${product}-${version}-bin.jar",
+  }
+}


### PR DESCRIPTION
I copied this from the Jira module with slight alterations to prevent conflicts between the Jira and Confluence modules. There is likely a better way to do this but I needed a quick solution. I am open to refactoring this.

