### PR TITLE
Add checksum for modules default version

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,8 +304,8 @@ Default: '<http://www.atlassian.com/software/confluence/downloads/binary/>'
 
 ##### `checksum`
 
-iThe md5 checksum of the archive file. Only supported with
-`deploy_module => archive`. Defaults to 'undef'
+The md5 checksum of the archive file. Only supported with
+`deploy_module => archive`. Defaults to '8c97aa3f157f954977839de6a6b47d48'
 
 ##### `manage_service`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -27,7 +27,7 @@ class confluence (
 
   # Misc Settings
   $download_url = 'http://www.atlassian.com/software/confluence/downloads/binary',
-  $checksum     = undef,
+  $checksum     = '8c97aa3f157f954977839de6a6b47d48',
 
   # Choose whether to use puppet-staging, or puppet-archive
   $deploy_module = 'archive',


### PR DESCRIPTION
As long as Atlassian does not provide checksums, we should at least supply one for the default version so that the installation is as straightforward as possible.