### PR TITLE
Use https instead of http

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,8 @@ as Ubuntu 12.04 can use 'template'.
 
 ##### `download_url`
 
-Default: '<http://www.atlassian.com/software/confluence/downloads/binary/>'
+The URL used to download the JIRA installation file.
+Defaults to '<https://www.atlassian.com/software/confluence/downloads/binary>'
 
 ##### `checksum`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -26,7 +26,7 @@ class confluence (
   $shell        = '/bin/true',
 
   # Misc Settings
-  $download_url = 'http://www.atlassian.com/software/confluence/downloads/binary',
+  $download_url = 'https://www.atlassian.com/software/confluence/downloads/binary',
   $checksum     = undef,
 
   # Choose whether to use puppet-staging, or puppet-archive

--- a/spec/classes/confluence_install_spec.rb
+++ b/spec/classes/confluence_install_spec.rb
@@ -27,8 +27,8 @@ describe 'confluence' do
 
       it 'deploys confluence 5.5.6 from tar.gz' do
         is_expected.to contain_archive('/tmp/atlassian-confluence-5.5.6.tar.gz').
-          with('extract_path' => '/opt/confluence/atlassian-confluence-5.5.6',
-               'source'        => 'http://www.atlassian.com/software/confluence/downloads/binary/atlassian-confluence-5.5.6.tar.gz',
+          with('extract_path'  => '/opt/confluence/atlassian-confluence-5.5.6',
+               'source'        => 'https://www.atlassian.com/software/confluence/downloads/binary/atlassian-confluence-5.5.6.tar.gz',
                'creates'       => '/opt/confluence/atlassian-confluence-5.5.6/conf',
                'user'          => 'confluence',
                'group'         => 'confluence',
@@ -71,7 +71,7 @@ describe 'confluence' do
 
       it 'deploys confluence 5.5.5 from tar.gz' do
         is_expected.to contain_archive('/tmp/atlassian-confluence-5.5.5.tar.gz').
-          with('extract_path' => '/opt/foo/confluence/atlassian-confluence-5.5.5',
+          with('extract_path'  => '/opt/foo/confluence/atlassian-confluence-5.5.5',
                'source'        => 'http://downloads.atlassian.com/atlassian-confluence-5.5.5.tar.gz',
                'creates'       => '/opt/foo/confluence/atlassian-confluence-5.5.5/conf',
                'user'          => 'foo',


### PR DESCRIPTION
We should use https instead of http, even if Atlassian redirects the traffic automatically.