### PR TITLE
Bump puppet minimum version_requirement to 3.8.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ Enable external facts for confluence version. Defaults to present.
 
 ## Limitations
 
-* Puppet 3.4+
+* Puppet 3.8.7+
 * Puppet Enterprise
 
 The puppetlabs repositories can be found at:

--- a/metadata.json
+++ b/metadata.json
@@ -24,12 +24,8 @@
   ],
   "requirements": [
     {
-      "name": "pe",
-      "version_requirement": "3.x"
-    },
-    {
       "name": "puppet",
-      "version_requirement": ">=3.4.0 <4.0.0"
+      "version_requirement": ">=3.8.7 < 5.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
We currently only run automated tests against Puppet 3 latest and
therefore cannot guarantee that this module works as is expected with
earlier Puppet 3 versions

Also add Puppet 4 support
Also remove deprecated pe verson_requirement field