### PR TITLE
Bump minimum version dependencies (for Puppet 4)

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -11,15 +11,15 @@
   "dependencies": [
     {
       "name": "puppet/archive",
-      "version_requirement": ">= 0.4.4"
+      "version_requirement": ">= 1.0.0 < 2.0.0"
     },
     {
       "name": "puppet/staging",
-      "version_requirement": ">= 1.0.0"
+      "version_requirement": ">= 2.0.1 < 3.0.0"
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.0.0"
+      "version_requirement": ">= 4.6.0 < 5.0.0"
     }
   ],
   "requirements": [


### PR DESCRIPTION
Bump dependencies to the minimum version that should work
under Puppet 4, based on the metadata