### PR TITLE
Default $data_dir to undef instead of empty string

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,7 +17,7 @@ class confluence (
   $format       = 'tar.gz',
   $installdir   = '/opt/confluence',
   $homedir      = '/home/confluence',
-  $data_dir     = '',
+  $data_dir     = undef,
   $user         = 'confluence',
   $group        = 'confluence',
   $uid          = undef,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,7 @@ end
 require 'puppetlabs_spec_helper/module_spec_helper'
 RSpec.configure do |c|
   c.default_facts = {
+    os: { family: 'Debian' },
     osfamily: 'Debian',
     augeasversion: '1.0.0',
     staging_http_get: 'curl',


### PR DESCRIPTION
Conditionals in the code expect this to be a truthy value. The empty string hasn't been `false` in a very long time.

Fixes #111

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
