### PR TITLE
Issue 119: updated facter script to not report java version

### DIFF
--- a/lib/facter/confluence_version.rb
+++ b/lib/facter/confluence_version.rb
@@ -1,11 +1,12 @@
 Facter.add(:confluence_version) do
   setcode do
     ps = Facter::Util::Resolution.exec('ps ax')
-    confluence_process = ps && ps.split("\n").find { |x| x.include?('atlassian-confluence') }
-    if confluence_process.nil?
+    confluence_process = ps && ps.split("\n").find { |x| x.include?('atlassian-confluence-') }
+    confluence_process =~ /^.*atlassian-confluence-(\d+\.\d+\.\d+).*/
+    if $1.nil?
       'unknown'
     else
-      confluence_process.scan(%r{\d+\.\d+\.\d+}).first
+      $1
     end
   end
 end

--- a/lib/facter/confluence_version.rb
+++ b/lib/facter/confluence_version.rb
@@ -8,6 +8,6 @@ Facter.add(:confluence_version) do
       'unknown'
     else
       Regexp.last_match(1)
-   end
+    end
   end
 end

--- a/lib/facter/confluence_version.rb
+++ b/lib/facter/confluence_version.rb
@@ -2,11 +2,11 @@ Facter.add(:confluence_version) do
   setcode do
     ps = Facter::Util::Resolution.exec('ps ax')
     confluence_process = ps && ps.split("\n").find { |x| x.include?('atlassian-confluence-') }
-    confluence_process =~ /^.*atlassian-confluence-(\d+\.\d+\.\d+).*/
-    if $1.nil?
+    confluence_process =~ %r{^.*atlassian-confluence-(\d+\.\d+\.\d+).*}
+    if Regexp.last_match(1).nil?
       'unknown'
     else
-      $1
+      Regexp.last_match(1)
     end
   end
 end

--- a/lib/facter/confluence_version.rb
+++ b/lib/facter/confluence_version.rb
@@ -1,12 +1,13 @@
 Facter.add(:confluence_version) do
   setcode do
-    ps = Facter::Util::Resolution.exec('ps ax')
-    confluence_process = ps && ps.split("\n").find { |x| x.include?('atlassian-confluence-') }
-    confluence_process =~ %r{^.*atlassian-confluence-(\d+\.\d+\.\d+).*}
+    pgrep = Facter::Util::Resolution.exec(
+      'pgrep --list-full --full java.*atlassian-confluence-[0-9].*org.apache.catalina.startup.Bootstrap'
+    )
+    pgrep.to_s =~ %r{^.*atlassian-confluence-(\d+\.\d+\.\d+).*}
     if Regexp.last_match(1).nil?
       'unknown'
     else
       Regexp.last_match(1)
-    end
+   end
   end
 end

--- a/spec/unit/facter/util/fact_confluence_version_spec.rb
+++ b/spec/unit/facter/util/fact_confluence_version_spec.rb
@@ -12,6 +12,17 @@ describe Facter::Util::Fact do
       expect(Facter.fact(:confluence_version).value).to eq('5.7.1')
     end
   end
+  
+  context 'confluence_version with confluence running non-standard java' do
+    before do
+      Facter.clear
+      Facter.fact(:kernel).stubs(:value).returns('Linux')
+      Facter::Util::Resolution.stubs(:exec).with('ps ax').returns('27999 ?        Sl   101:06 /usr/lib/jvm/java-1.8.0-oracle/bin/java -Djava.util.logging.config.file=/opt/confluence/atlassian-confluence-5.7.1/conf/logging.properties -Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager -Xms256m -Xmx1024m -XX:MaxPermSize=256m -Djava.awt.headless=true -Djava.endorsed.dirs=/opt/confluence/atlassian-confluence-5.7.1/endorsed -classpath /opt/confluence/atlassian-confluence-5.7.1/bin/bootstrap.jar:/opt/confluence/atlassian-confluence-5.7.1/bin/tomcat-juli.jar -Dcatalina.base=/opt/confluence/atlassian-confluence-5.7.1 -Dcatalina.home=/opt/confluence/atlassian-confluence-5.7.1 -Djava.io.tmpdir=/opt/confluence/atlassian-confluence-5.7.1/temp org.apache.catalina.startup.Bootstrap start')
+    end
+    it 'returns the running version' do
+      expect(Facter.fact(:confluence_version).value).to eq('5.7.1')
+    end
+  end
 
   context 'confluence_version with confulence not running' do
     before do

--- a/spec/unit/facter/util/fact_confluence_version_spec.rb
+++ b/spec/unit/facter/util/fact_confluence_version_spec.rb
@@ -12,7 +12,7 @@ describe Facter::Util::Fact do
       expect(Facter.fact(:confluence_version).value).to eq('5.7.1')
     end
   end
-  
+
   context 'confluence_version with confluence running non-standard java' do
     before do
       Facter.clear


### PR DESCRIPTION
The facter script was reporting the java version instead of the confluence version. Looking for the first thing on the ps line which looks like a version is not ideal.

Unfortunately the rest API does not seem to provide a version. Jira does; Atlassian are very inconsistent.

This change simply improves on the string matching on the ps line a bit.

This stopped our server from trying to 'upgrade' from 1.8.0 (java version) to 6.0.x.
