### PR TITLE
Issue 119: updated facter script to not report java version

### DIFF
--- a/lib/facter/confluence_version.rb
+++ b/lib/facter/confluence_version.rb
@@ -1,11 +1,13 @@
 Facter.add(:confluence_version) do
   setcode do
-    ps = Facter::Util::Resolution.exec('ps ax')
-    confluence_process = ps && ps.split("\n").find { |x| x.include?('atlassian-confluence') }
-    if confluence_process.nil?
+    pgrep = Facter::Util::Resolution.exec(
+      'pgrep --list-full --full java.*atlassian-confluence-[0-9].*org.apache.catalina.startup.Bootstrap'
+    )
+    pgrep.to_s =~ %r{^.*atlassian-confluence-(\d+\.\d+\.\d+).*}
+    if Regexp.last_match(1).nil?
       'unknown'
     else
-      confluence_process.scan(%r{\d+\.\d+\.\d+}).first
+      Regexp.last_match(1)
     end
   end
 end

--- a/spec/unit/facter/util/fact_confluence_version_spec.rb
+++ b/spec/unit/facter/util/fact_confluence_version_spec.rb
@@ -2,11 +2,23 @@ require 'spec_helper'
 require 'facter/confluence_version'
 
 describe Facter::Util::Fact do
+  pgrep_line='pgrep --list-full --full java.*atlassian-confluence-[0-9].*org.apache.catalina.startup.Bootstrap'
   context 'confluence_version with confluence running' do
     before do
       Facter.clear
       Facter.fact(:kernel).stubs(:value).returns('Linux')
-      Facter::Util::Resolution.stubs(:exec).with('ps ax').returns('27999 ?        Sl   101:06 /usr//bin/java -Djava.util.logging.config.file=/opt/confluence/atlassian-confluence-5.7.1/conf/logging.properties -Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager -Xms256m -Xmx1024m -XX:MaxPermSize=256m -Djava.awt.headless=true -Djava.endorsed.dirs=/opt/confluence/atlassian-confluence-5.7.1/endorsed -classpath /opt/confluence/atlassian-confluence-5.7.1/bin/bootstrap.jar:/opt/confluence/atlassian-confluence-5.7.1/bin/tomcat-juli.jar -Dcatalina.base=/opt/confluence/atlassian-confluence-5.7.1 -Dcatalina.home=/opt/confluence/atlassian-confluence-5.7.1 -Djava.io.tmpdir=/opt/confluence/atlassian-confluence-5.7.1/temp org.apache.catalina.startup.Bootstrap start')
+      Facter::Util::Resolution.stubs(:exec).with(pgrep_line).returns('27999 /usr//bin/java -Djava.util.logging.config.file=/opt/confluence/atlassian-confluence-5.7.1/conf/logging.properties -Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager -Xms256m -Xmx1024m -XX:MaxPermSize=256m -Djava.awt.headless=true -Djava.endorsed.dirs=/opt/confluence/atlassian-confluence-5.7.1/endorsed -classpath /opt/confluence/atlassian-confluence-5.7.1/bin/bootstrap.jar:/opt/confluence/atlassian-confluence-5.7.1/bin/tomcat-juli.jar -Dcatalina.base=/opt/confluence/atlassian-confluence-5.7.1 -Dcatalina.home=/opt/confluence/atlassian-confluence-5.7.1 -Djava.io.tmpdir=/opt/confluence/atlassian-confluence-5.7.1/temp org.apache.catalina.startup.Bootstrap start')
+    end
+    it 'returns the running version' do
+      expect(Facter.fact(:confluence_version).value).to eq('5.7.1')
+    end
+  end
+
+  context 'confluence_version with confluence running non-standard java' do
+    before do
+      Facter.clear
+      Facter.fact(:kernel).stubs(:value).returns('Linux')
+      Facter::Util::Resolution.stubs(:exec).with(pgrep_line).returns('27999 /usr/lib/jvm/java-1.8.0-oracle/bin/java -Djava.util.logging.config.file=/opt/confluence/atlassian-confluence-5.7.1/conf/logging.properties -Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager -Xms256m -Xmx1024m -XX:MaxPermSize=256m -Djava.awt.headless=true -Djava.endorsed.dirs=/opt/confluence/atlassian-confluence-5.7.1/endorsed -classpath /opt/confluence/atlassian-confluence-5.7.1/bin/bootstrap.jar:/opt/confluence/atlassian-confluence-5.7.1/bin/tomcat-juli.jar -Dcatalina.base=/opt/confluence/atlassian-confluence-5.7.1 -Dcatalina.home=/opt/confluence/atlassian-confluence-5.7.1 -Djava.io.tmpdir=/opt/confluence/atlassian-confluence-5.7.1/temp org.apache.catalina.startup.Bootstrap start')
     end
     it 'returns the running version' do
       expect(Facter.fact(:confluence_version).value).to eq('5.7.1')
@@ -17,7 +29,7 @@ describe Facter::Util::Fact do
     before do
       Facter.clear
       Facter.fact(:kernel).stubs(:value).returns('Linux')
-      Facter::Util::Resolution.stubs(:exec).with('ps ax').returns('')
+      Facter::Util::Resolution.stubs(:exec).with(pgrep_line).returns('')
     end
     it 'returns "unknown"' do
       expect(Facter.fact(:confluence_version).value).to eq('unknown')

--- a/spec/unit/facter/util/fact_confluence_version_spec.rb
+++ b/spec/unit/facter/util/fact_confluence_version_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'facter/confluence_version'
 
 describe Facter::Util::Fact do
-  pgrep_line='pgrep --list-full --full java.*atlassian-confluence-[0-9].*org.apache.catalina.startup.Bootstrap'
+  pgrep_line = 'pgrep --list-full --full java.*atlassian-confluence-[0-9].*org.apache.catalina.startup.Bootstrap'
   context 'confluence_version with confluence running' do
     before do
       Facter.clear


### PR DESCRIPTION
The facter script was reporting the java version instead of the confluence version. Looking for the first thing on the ps line which looks like a version is not ideal.

Unfortunately the rest API does not seem to provide a version. Jira does; Atlassian are very inconsistent.

This change simply improves on the string matching on the ps line a bit.

This stopped our server from trying to 'upgrade' from 1.8.0 (java version) to 6.0.x.
