### PR TITLE
Ubuntu 16.04 Support (systemd)

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ The puppetlabs repositories can be found at:
 <http://yum.puppetlabs.com/> and <http://apt.puppetlabs.com/>
 
 * RedHat / CentOS 5/6/7
-* Ubuntu 12.04 / 14.04
+* Ubuntu 12.04 / 14.04 / 16.04
 * Debian 7
 
 Operating Systems without an Augueas version >= 1 such as Ubuntu 12.04 must use

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,10 +10,12 @@ class confluence::params {
         $service_file_location = '/usr/lib/systemd/system/confluence.service'
         $service_file_template = 'confluence/confluence.service.erb'
         $service_lockfile      = '/var/lock/subsys/confluence'
+        $refresh_systemd       = true
       } elsif $::operatingsystemmajrelease == '6' {
         $service_file_location = '/etc/init.d/confluence'
         $service_file_template = 'confluence/confluence.initscript.erb'
         $service_lockfile      = '/var/lock/subsys/confluence'
+        $refresh_systemd       = false
       } else {
         fail("Only osfamily ${::osfamily} 6 and 7 and supported")
       }
@@ -26,11 +28,13 @@ class confluence::params {
               $service_file_location   = '/etc/systemd/system/confluence.service'
               $service_file_template   = 'confluence/confluence.service.erb'
               $service_lockfile        = '/var/lock/subsys/confluence'
+              $refresh_systemd         = true
             }
             default: {
               $service_file_location   = '/etc/init.d/confluence'
               $service_file_template   = 'confluence/confluence.initscript.erb'
               $service_lockfile        = '/var/lock/confluence'
+              $refresh_systemd         = false
             }
           }
         }
@@ -38,6 +42,7 @@ class confluence::params {
           $service_file_location   = '/etc/init.d/confluence'
           $service_file_template   = 'confluence/confluence.initscript.erb'
           $service_lockfile        = '/var/lock/confluence'
+          $refresh_systemd         = false
         }
       }
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,9 +19,27 @@ class confluence::params {
       }
     }
     /Debian/: {
-      $service_file_location   = '/etc/init.d/confluence'
-      $service_file_template   = 'confluence/confluence.initscript.erb'
-      $service_lockfile        = '/var/lock/confluence'
+      case $::operatingsystem {
+        /Ubuntu/: {
+          case $::operatingsystemmajrelease {
+            /^16.04$/: {
+              $service_file_location   = '/etc/systemd/system/confluence.service'
+              $service_file_template   = 'confluence/confluence.service.erb'
+              $service_lockfile        = '/var/lock/subsys/confluence'
+            }
+            default: {
+              $service_file_location   = '/etc/init.d/confluence'
+              $service_file_template   = 'confluence/confluence.initscript.erb'
+              $service_lockfile        = '/var/lock/confluence'
+            }
+          }
+        }
+        default: {
+          $service_file_location   = '/etc/init.d/confluence'
+          $service_file_template   = 'confluence/confluence.initscript.erb'
+          $service_lockfile        = '/var/lock/confluence'
+        }
+      }
     }
     default: { fail('Only osfamily Debian and Redhat are supported') }
   }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -6,11 +6,22 @@ class confluence::service(
   $service_file_location = $confluence::params::service_file_location,
   $service_file_template = $confluence::params::service_file_template,
   $service_lockfile      = $confluence::params::service_lockfile,
+  $refresh_systemd       = $confluence::params::refresh_systemd,
 )  {
 
   file { $service_file_location:
     content => template($service_file_template),
     mode    => '0755',
+  }
+
+  if $refresh_systemd {
+    exec { 'systemctl_reload_confluence':
+      command     => 'systemctl daemon-reload',
+      path        => '/bin:/sbin:/usr/bin:/usr/sbin',
+      refreshonly => true,
+      subscribe   => File[$service_file_location],
+      before      => Service['confluence'],
+    }
   }
 
   if $confluence::manage_service {


### PR DESCRIPTION
This adds systemd support for Ubuntu 16.04. I also added a `systemctl daemon-reload` for RHEL7 and Ubuntu 16.04 to make sure systemd uses the new unit file when it changes (e.g. during upgrade of confluence).
