### PR TITLE
Fix incorrect failures with rspec-puppet-facts

### DIFF
--- a/spec/classes/confluence_config_spec.rb
+++ b/spec/classes/confluence_config_spec.rb
@@ -1,130 +1,131 @@
 require 'spec_helper.rb'
 
 describe 'confluence' do
-  describe 'confluence::config' do
-    let :facts do
-      {
-        os: { family: 'RedHat' },
-        operatingsystem: 'RedHat'
-      }
-    end
-
-    context 'default params' do
-      let(:params) do
-        {
-          javahome: '/opt/java',
-          version: '5.5.6'
-        }
+  on_supported_os.each do |os, fs_facts|
+    context "on #{os}" do
+      let :facts do
+        fs_facts
       end
 
-      it { is_expected.to compile.with_all_deps }
-      it { is_expected.to contain_file('/opt/confluence/atlassian-confluence-5.5.6/bin/setenv.sh') }
-      it { is_expected.to contain_file('/opt/confluence/atlassian-confluence-5.5.6/confluence/WEB-INF/classes/confluence-init.properties') }
-      it { is_expected.to contain_augeas('/opt/confluence/atlassian-confluence-5.5.6/conf/server.xml') }
-    end
-    context 'with param manage_server_xml set to template' do
-      let(:params) do
-        {
-          javahome: '/opt/java',
-          version: '5.5.6',
-          manage_server_xml: 'template'
-        }
-      end
+      describe 'confluence::config' do
+        context 'default params' do
+          let(:params) do
+            {
+              javahome: '/opt/java',
+              version: '5.5.6'
+            }
+          end
 
-      it { is_expected.to contain_file('/opt/confluence/atlassian-confluence-5.5.6/bin/setenv.sh') }
-      it { is_expected.to contain_file('/opt/confluence/atlassian-confluence-5.5.6/confluence/WEB-INF/classes/confluence-init.properties') }
-      it { is_expected.to contain_file('/opt/confluence/atlassian-confluence-5.5.6/conf/server.xml') }
-    end
-    context 'with param manage_server_xml set to template and non default params' do
-      let(:params) do
-        {
-          javahome: '/opt/java',
-          version: '5.5.6',
-          manage_server_xml: 'template',
-          context_path: '/confluence1',
-          tomcat_port: 8089,
-          tomcat_max_threads: 999,
-          tomcat_accept_count: 999,
-          tomcat_proxy: {
-            'scheme'      => 'https',
-            'proxyName'   => 'EXAMPLE',
-            'proxyPort'   => '443'
-          }
-        }
-      end
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_file('/opt/confluence/atlassian-confluence-5.5.6/bin/setenv.sh') }
+          it { is_expected.to contain_file('/opt/confluence/atlassian-confluence-5.5.6/confluence/WEB-INF/classes/confluence-init.properties') }
+          it { is_expected.to contain_augeas('/opt/confluence/atlassian-confluence-5.5.6/conf/server.xml') }
+        end
+        context 'with param manage_server_xml set to template' do
+          let(:params) do
+            {
+              javahome: '/opt/java',
+              version: '5.5.6',
+              manage_server_xml: 'template'
+            }
+          end
 
-      it { is_expected.to contain_file('/opt/confluence/atlassian-confluence-5.5.6/bin/setenv.sh') }
-      it { is_expected.to contain_file('/opt/confluence/atlassian-confluence-5.5.6/confluence/WEB-INF/classes/confluence-init.properties') }
-      it do
-        is_expected.to contain_file('/opt/confluence/atlassian-confluence-5.5.6/conf/server.xml').
-          with_content(%r{port="8089"}).
-          with_content(%r{maxThreads="999"}).
-          with_content(%r{acceptCount="999"}).
-          with_content(%r{scheme="https"}).
-          with_content(%r{proxyName="EXAMPLE"}).
-          with_content(%r{proxyPort="443"}).
-          with_content(%r{Context path="/confluence1"})
-      end
-    end
-    context 'with param data_dir set' do
-      let(:params) do
-        {
-          javahome: '/opt/java',
-          version: '5.5.6',
-          data_dir: '/opt/confluence/confluence-data'
-        }
-      end
+          it { is_expected.to contain_file('/opt/confluence/atlassian-confluence-5.5.6/bin/setenv.sh') }
+          it { is_expected.to contain_file('/opt/confluence/atlassian-confluence-5.5.6/confluence/WEB-INF/classes/confluence-init.properties') }
+          it { is_expected.to contain_file('/opt/confluence/atlassian-confluence-5.5.6/conf/server.xml') }
+        end
+        context 'with param manage_server_xml set to template and non default params' do
+          let(:params) do
+            {
+              javahome: '/opt/java',
+              version: '5.5.6',
+              manage_server_xml: 'template',
+              context_path: '/confluence1',
+              tomcat_port: 8089,
+              tomcat_max_threads: 999,
+              tomcat_accept_count: 999,
+              tomcat_proxy: {
+                'scheme'      => 'https',
+                'proxyName'   => 'EXAMPLE',
+                'proxyPort'   => '443'
+              }
+            }
+          end
 
-      it do
-        is_expected.to contain_file('/opt/confluence/atlassian-confluence-5.5.6/confluence/WEB-INF/classes/confluence-init.properties').
-          with_content(%r{confluence.home=/opt/confluence/confluence-data})
-      end
-    end
-    context 'with param data_dir not set and param homdir set' do
-      let(:params) do
-        {
-          javahome: '/opt/java',
-          version: '5.5.6',
-          homedir: '/opt/confluence/confluence-home'
-        }
-      end
+          it { is_expected.to contain_file('/opt/confluence/atlassian-confluence-5.5.6/bin/setenv.sh') }
+          it { is_expected.to contain_file('/opt/confluence/atlassian-confluence-5.5.6/confluence/WEB-INF/classes/confluence-init.properties') }
+          it do
+            is_expected.to contain_file('/opt/confluence/atlassian-confluence-5.5.6/conf/server.xml').
+              with_content(%r{port="8089"}).
+              with_content(%r{maxThreads="999"}).
+              with_content(%r{acceptCount="999"}).
+              with_content(%r{scheme="https"}).
+              with_content(%r{proxyName="EXAMPLE"}).
+              with_content(%r{proxyPort="443"}).
+              with_content(%r{Context path="/confluence1"})
+          end
+        end
+        context 'with param data_dir set' do
+          let(:params) do
+            {
+              javahome: '/opt/java',
+              version: '5.5.6',
+              data_dir: '/opt/confluence/confluence-data'
+            }
+          end
 
-      it do
-        is_expected.to contain_file('/opt/confluence/atlassian-confluence-5.5.6/confluence/WEB-INF/classes/confluence-init.properties').
-          with_content(%r{confluence.home=/opt/confluence/confluence-home})
-      end
-    end
-    context 'with param data_dir set and param homdir set' do
-      let(:params) do
-        {
-          javahome: '/opt/java',
-          version: '5.5.6',
-          data_dir: '/opt/confluence/confluence-data',
-          homedir: '/opt/confluence/confluence-home'
-        }
-      end
+          it do
+            is_expected.to contain_file('/opt/confluence/atlassian-confluence-5.5.6/confluence/WEB-INF/classes/confluence-init.properties').
+              with_content(%r{confluence.home=/opt/confluence/confluence-data})
+          end
+        end
+        context 'with param data_dir not set and param homdir set' do
+          let(:params) do
+            {
+              javahome: '/opt/java',
+              version: '5.5.6',
+              homedir: '/opt/confluence/confluence-home'
+            }
+          end
 
-      it do
-        is_expected.to contain_file('/opt/confluence/atlassian-confluence-5.5.6/confluence/WEB-INF/classes/confluence-init.properties').
-          with_content(%r{confluence.home=/opt/confluence/confluence-data})
-      end
-    end
-    context 'ajp proxy' do
-      let(:params) do
-        {
-          version: '5.5.6',
-          javahome: '/opt/java',
-          manage_server_xml: 'template',
-          ajp: {
-            'port'     => '8009',
-            'protocol' => 'AJP/1.3'
-          }
-        }
-      end
+          it do
+            is_expected.to contain_file('/opt/confluence/atlassian-confluence-5.5.6/confluence/WEB-INF/classes/confluence-init.properties').
+              with_content(%r{confluence.home=/opt/confluence/confluence-home})
+          end
+        end
+        context 'with param data_dir set and param homdir set' do
+          let(:params) do
+            {
+              javahome: '/opt/java',
+              version: '5.5.6',
+              data_dir: '/opt/confluence/confluence-data',
+              homedir: '/opt/confluence/confluence-home'
+            }
+          end
 
-      it do
-        is_expected.to contain_file('/opt/confluence/atlassian-confluence-5.5.6/conf/server.xml').
-          with_content(%r{<Connector enableLookups="false" URIEncoding="UTF-8"\s+port = "8009"\s+protocol = "AJP/1.3"\s+/>})
+          it do
+            is_expected.to contain_file('/opt/confluence/atlassian-confluence-5.5.6/confluence/WEB-INF/classes/confluence-init.properties').
+              with_content(%r{confluence.home=/opt/confluence/confluence-data})
+          end
+        end
+        context 'ajp proxy' do
+          let(:params) do
+            {
+              version: '5.5.6',
+              javahome: '/opt/java',
+              manage_server_xml: 'template',
+              ajp: {
+                'port'     => '8009',
+                'protocol' => 'AJP/1.3'
+              }
+            }
+          end
+
+          it do
+            is_expected.to contain_file('/opt/confluence/atlassian-confluence-5.5.6/conf/server.xml').
+              with_content(%r{<Connector enableLookups="false" URIEncoding="UTF-8"\s+port = "8009"\s+protocol = "AJP/1.3"\s+/>})
+          end
+        end
       end
     end
   end

--- a/spec/classes/confluence_install_spec.rb
+++ b/spec/classes/confluence_install_spec.rb
@@ -1,96 +1,97 @@
 require 'spec_helper.rb'
 
 describe 'confluence' do
-  describe 'confluence::install' do
-    let :facts do
-      {
-        os: { family: 'RedHat' },
-        operatingsystem: 'RedHat'
-      }
-    end
-
-    context 'default params' do
-      let(:params) do
-        {
-          javahome: '/opt/java',
-          version: '5.5.6',
-          user: 'confluence',
-          group: 'confluence',
-          installdir: '/opt/confluence',
-          homedir: '/home/confluence',
-          format: 'tar.gz',
-          product: 'confluence'
-        }
+  on_supported_os.each do |os, fs_facts|
+    context "on #{os}" do
+      let :facts do
+        fs_facts
       end
 
-      it { is_expected.to compile.with_all_deps }
+      describe 'confluence::install' do
+        context 'default params' do
+          let(:params) do
+            {
+              javahome: '/opt/java',
+              version: '5.5.6',
+              user: 'confluence',
+              group: 'confluence',
+              installdir: '/opt/confluence',
+              homedir: '/home/confluence',
+              format: 'tar.gz',
+              product: 'confluence'
+            }
+          end
 
-      it 'creates a system group' do
-        is_expected.to contain_group('confluence').with_system(true)
-      end
+          it { is_expected.to compile.with_all_deps }
 
-      it 'creates a system user with no shell' do
-        is_expected.to contain_user('confluence').with('shell' => '/bin/true',
-                                                       'system' => true)
-      end
+          it 'creates a system group' do
+            is_expected.to contain_group('confluence').with_system(true)
+          end
 
-      it 'deploys confluence 5.5.6 from tar.gz' do
-        is_expected.to contain_archive('/tmp/atlassian-confluence-5.5.6.tar.gz').
-          with('extract_path'  => '/opt/confluence/atlassian-confluence-5.5.6',
-               'source'        => 'https://www.atlassian.com/software/confluence/downloads/binary/atlassian-confluence-5.5.6.tar.gz',
-               'creates'       => '/opt/confluence/atlassian-confluence-5.5.6/conf',
-               'user'          => 'confluence',
-               'group'         => 'confluence',
-               'checksum_type' => 'md5')
-      end
+          it 'creates a system user with no shell' do
+            is_expected.to contain_user('confluence').with('shell' => '/bin/true',
+                                                           'system' => true)
+          end
 
-      it 'manages the confluence home directory' do
-        is_expected.to contain_file('/home/confluence').with('ensure' => 'directory',
-                                                             'owner' => 'confluence',
-                                                             'group' => 'confluence')
-      end
-    end
+          it 'deploys confluence 5.5.6 from tar.gz' do
+            is_expected.to contain_archive('/tmp/atlassian-confluence-5.5.6.tar.gz').
+              with('extract_path'  => '/opt/confluence/atlassian-confluence-5.5.6',
+                   'source'        => 'https://www.atlassian.com/software/confluence/downloads/binary/atlassian-confluence-5.5.6.tar.gz',
+                   'creates'       => '/opt/confluence/atlassian-confluence-5.5.6/conf',
+                   'user'          => 'confluence',
+                   'group'         => 'confluence',
+                   'checksum_type' => 'md5')
+          end
 
-    context 'overwriting params' do
-      let(:params) do
-        {
-          javahome: '/opt/java',
-          version: '5.5.5',
-          product: 'confluence',
-          format: 'tar.gz',
-          installdir: '/opt/foo/confluence',
-          homedir: '/random/homedir',
-          user: 'foo',
-          group: 'bar',
-          uid: 333,
-          gid: 444,
-          shell: '/bin/bash',
-          download_url: 'http://downloads.atlassian.com'
-        }
-      end
+          it 'manages the confluence home directory' do
+            is_expected.to contain_file('/home/confluence').with('ensure' => 'directory',
+                                                                 'owner' => 'confluence',
+                                                                 'group' => 'confluence')
+          end
+        end
 
-      it do
-        is_expected.to contain_user('foo').with('home' => '/random/homedir',
-                                                'shell' => '/bin/bash',
-                                                'uid'   => 333,
-                                                'gid'   => 444)
-      end
+        context 'overwriting params' do
+          let(:params) do
+            {
+              javahome: '/opt/java',
+              version: '5.5.5',
+              product: 'confluence',
+              format: 'tar.gz',
+              installdir: '/opt/foo/confluence',
+              homedir: '/random/homedir',
+              user: 'foo',
+              group: 'bar',
+              uid: 333,
+              gid: 444,
+              shell: '/bin/bash',
+              download_url: 'http://downloads.atlassian.com'
+            }
+          end
 
-      it { is_expected.to contain_group('bar') }
+          it do
+            is_expected.to contain_user('foo').with('home' => '/random/homedir',
+                                                    'shell' => '/bin/bash',
+                                                    'uid'   => 333,
+                                                    'gid'   => 444)
+          end
 
-      it 'deploys confluence 5.5.5 from tar.gz' do
-        is_expected.to contain_archive('/tmp/atlassian-confluence-5.5.5.tar.gz').
-          with('extract_path'  => '/opt/foo/confluence/atlassian-confluence-5.5.5',
-               'source'        => 'http://downloads.atlassian.com/atlassian-confluence-5.5.5.tar.gz',
-               'creates'       => '/opt/foo/confluence/atlassian-confluence-5.5.5/conf',
-               'user'          => 'foo',
-               'group'         => 'bar',
-               'checksum_type' => 'md5')
-      end
-      it 'manages the confluence home directory' do
-        is_expected.to contain_file('/random/homedir').with('ensure' => 'directory',
-                                                            'owner' => 'foo',
-                                                            'group' => 'bar')
+          it { is_expected.to contain_group('bar') }
+
+          it 'deploys confluence 5.5.5 from tar.gz' do
+            is_expected.to contain_archive('/tmp/atlassian-confluence-5.5.5.tar.gz').
+              with('extract_path'  => '/opt/foo/confluence/atlassian-confluence-5.5.5',
+                   'source'        => 'http://downloads.atlassian.com/atlassian-confluence-5.5.5.tar.gz',
+                   'creates'       => '/opt/foo/confluence/atlassian-confluence-5.5.5/conf',
+                   'user'          => 'foo',
+                   'group'         => 'bar',
+                   'checksum_type' => 'md5')
+          end
+          it 'manages the confluence home directory' do
+            is_expected.to contain_file('/random/homedir').with('ensure' => 'directory',
+                                                                'owner' => 'foo',
+                                                                'group' => 'bar')
+          end
+        end
       end
     end
   end

--- a/spec/classes/confluence_service_spec.rb
+++ b/spec/classes/confluence_service_spec.rb
@@ -2,23 +2,31 @@ require 'spec_helper.rb'
 
 describe 'confluence' do
   describe 'confluence::config' do
-    context 'default params' do
-      let(:params) do
-        {
-          javahome: '/opt/java',
-          version: '5.5.6'
-        }
-      end
+    on_supported_os.each do |os, fs_facts|
+      context "on #{os}" do
+        let :facts do
+          fs_facts
+        end
 
-      let :facts do
-        {
-          os: { family: 'RedHat' },
-          operatingsystem: 'RedHat'
-        }
-      end
+        context 'default params' do
+          let(:params) do
+            {
+              javahome: '/opt/java',
+              version: '5.5.6'
+            }
+          end
 
-      it { is_expected.to contain_service('confluence') }
-      it { is_expected.to compile.with_all_deps }
+          let :facts do
+            {
+              os: { family: 'RedHat' },
+              operatingsystem: 'RedHat'
+            }
+          end
+
+          it { is_expected.to contain_service('confluence') }
+          it { is_expected.to compile.with_all_deps }
+        end
+      end
     end
   end
 end

--- a/spec/classes/confluence_spec.rb
+++ b/spec/classes/confluence_spec.rb
@@ -1,28 +1,29 @@
 require 'spec_helper.rb'
 
 describe 'confluence' do
-  let :facts do
-    {
-      os: { family: 'RedHat' },
-      operatingsystem: 'RedHat'
-    }
-  end
+  on_supported_os.each do |os, fs_facts|
+    context "on #{os}" do
+      let :facts do
+        fs_facts
+      end
 
-  context 'with javahome not set' do
-    it('fails') do
-      is_expected.to raise_error(Puppet::Error, %r{You need to specify a value for javahome})
+      context 'with javahome not set' do
+        it('fails') do
+          is_expected.to raise_error(Puppet::Error, %r{You need to specify a value for javahome})
+        end
+      end
+
+      context 'with javahome set' do
+        let(:params) do
+          { javahome: '/foo/bar' }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_class('confluence') }
+        it { is_expected.to contain_class('confluence::install') }
+        it { is_expected.to contain_class('confluence::config') }
+        it { is_expected.to contain_class('confluence::service') }
+      end
     end
-  end
-
-  context 'with javahome set' do
-    let(:params) do
-      { javahome: '/foo/bar' }
-    end
-
-    it { is_expected.to compile.with_all_deps }
-    it { is_expected.to contain_class('confluence') }
-    it { is_expected.to contain_class('confluence::install') }
-    it { is_expected.to contain_class('confluence::config') }
-    it { is_expected.to contain_class('confluence::service') }
   end
 end

--- a/spec/classes/confluence_sso_spec.rb
+++ b/spec/classes/confluence_sso_spec.rb
@@ -1,64 +1,65 @@
 require 'spec_helper.rb'
 
 describe 'confluence' do
-  describe 'confluence::sso' do
-    let :facts do
-      {
-        os: { family: 'RedHat' },
-        operatingsystem: 'RedHat'
-      }
-    end
-
-    context 'default params' do
-      let(:params) do
-        {
-          javahome: '/opt/java',
-          version: '5.5.6',
-          enable_sso: true
-        }
+  on_supported_os.each do |os, fs_facts|
+    context "on #{os}" do
+      let :facts do
+        fs_facts
       end
 
-      it { is_expected.to compile.with_all_deps }
-      it { is_expected.to contain_file('/opt/confluence/atlassian-confluence-5.5.6/confluence/WEB-INF/classes/seraph-config.xml') }
-      it { is_expected.to contain_file('/opt/confluence/atlassian-confluence-5.5.6/confluence/WEB-INF/classes/crowd.properties') }
-    end
-    context 'with param application_name set to appname' do
-      let(:params) do
-        {
-          javahome: '/opt/java',
-          version: '5.5.6',
-          enable_sso: true,
-          application_name: 'appname'
-        }
-      end
+      describe 'confluence::sso' do
+        context 'default params' do
+          let(:params) do
+            {
+              javahome: '/opt/java',
+              version: '5.5.6',
+              enable_sso: true
+            }
+          end
 
-      it do
-        is_expected.to contain_file('/opt/confluence/atlassian-confluence-5.5.6/confluence/WEB-INF/classes/crowd.properties').
-          with_content(%r{application.name                        appname})
-      end
-    end
-    context 'with non default params' do
-      let(:params) do
-        {
-          javahome: '/opt/java',
-          version: '5.5.6',
-          enable_sso: true,
-          application_name: 'app',
-          application_password: 'password',
-          application_login_url: 'https://login.url/',
-          crowd_server_url: 'https://crowd.url/',
-          crowd_base_url: 'http://crowdbase.url'
-        }
-      end
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_file('/opt/confluence/atlassian-confluence-5.5.6/confluence/WEB-INF/classes/seraph-config.xml') }
+          it { is_expected.to contain_file('/opt/confluence/atlassian-confluence-5.5.6/confluence/WEB-INF/classes/crowd.properties') }
+        end
+        context 'with param application_name set to appname' do
+          let(:params) do
+            {
+              javahome: '/opt/java',
+              version: '5.5.6',
+              enable_sso: true,
+              application_name: 'appname'
+            }
+          end
 
-      it { is_expected.to contain_file('/opt/confluence/atlassian-confluence-5.5.6/confluence/WEB-INF/classes/seraph-config.xml') }
-      it do
-        is_expected.to contain_file('/opt/confluence/atlassian-confluence-5.5.6/confluence/WEB-INF/classes/crowd.properties').
-          with_content(%r{application.name                        app}).
-          with_content(%r{application.password                    password}).
-          with_content(%r{application.login.url                   https:\/\/login.url\/}).
-          with_content(%r{crowd.server.url                        https:\/\/crowd.url\/}).
-          with_content(%r{crowd.base.url                          http:\/\/crowdbase.url})
+          it do
+            is_expected.to contain_file('/opt/confluence/atlassian-confluence-5.5.6/confluence/WEB-INF/classes/crowd.properties').
+              with_content(%r{application.name                        appname})
+          end
+        end
+        context 'with non default params' do
+          let(:params) do
+            {
+              javahome: '/opt/java',
+              version: '5.5.6',
+              enable_sso: true,
+              application_name: 'app',
+              application_password: 'password',
+              application_login_url: 'https://login.url/',
+              crowd_server_url: 'https://crowd.url/',
+              crowd_base_url: 'http://crowdbase.url'
+            }
+          end
+
+          it { is_expected.to contain_file('/opt/confluence/atlassian-confluence-5.5.6/confluence/WEB-INF/classes/seraph-config.xml') }
+          it do
+            is_expected.to contain_file('/opt/confluence/atlassian-confluence-5.5.6/confluence/WEB-INF/classes/crowd.properties').
+              with_content(%r{application.name                        app}).
+              with_content(%r{application.password                    password}).
+              with_content(%r{application.login.url                   https:\/\/login.url\/}).
+              with_content(%r{crowd.server.url                        https:\/\/crowd.url\/}).
+              with_content(%r{crowd.base.url                          http:\/\/crowdbase.url})
+          end
+        end
       end
     end
   end

--- a/spec/classes/confluence_upgrade_spec.rb
+++ b/spec/classes/confluence_upgrade_spec.rb
@@ -1,41 +1,40 @@
 require 'spec_helper.rb'
 
 describe 'confluence' do
-  describe 'confluence::install' do
-    context 'default params' do
-      let(:params) do
-        {
-          javahome: '/opt/java'
-        }
+  on_supported_os.each do |os, fs_facts|
+    context "on #{os}" do
+      let :facts do
+        fs_facts
       end
 
-      let(:facts) do
-        {
-          confluence_version: '1.5.4',
-          os: { family: 'RedHat' },
-          operatingsystem: 'RedHat'
-        }
-      end
+      describe 'confluence::install' do
+        context 'default params' do
+          let(:params) do
+            {
+              javahome: '/opt/java'
+            }
+          end
+          let(:facts) do
+            fs_facts.merge(confluence_version: '1.5.4')
+          end
 
-      it { is_expected.to compile.with_all_deps }
-      it { is_expected.to contain_exec('service confluence stop && sleep 15') }
-    end
-    context 'custom params' do
-      let(:params) do
-        {
-          javahome: '/opt/java',
-          stop_confluence: 'stop service please'
-        }
-      end
-      let(:facts) do
-        {
-          confluence_version: '2.3.4a',
-          os: { family: 'RedHat' },
-          operatingsystem: 'RedHat'
-        }
-      end
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_exec('service confluence stop && sleep 15') }
+        end
+        context 'custom params' do
+          let(:params) do
+            {
+              javahome: '/opt/java',
+              stop_confluence: 'stop service please'
+            }
+          end
+          let(:facts) do
+            fs_facts.merge(confluence_version: '2.3.4a')
+          end
 
-      it { is_expected.to contain_exec('stop service please') }
+          it { is_expected.to contain_exec('stop service please') }
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Before this commit, running spec tests on some non-Debian systems would
fail with the message:

```
RuntimeError:
       Could not find the daemon directory (tested
       [/etc/sv,/var/lib/service])
```

This commit fixes issue #135 by converting each spec test to use a
complete set of sampled fact for each supported OS by using
the `on_supported_os` method from the `rspec-puppet-facts` gem.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
