### PR TITLE
Use 'ps' for version fact

### DIFF
--- a/lib/facter/confluence_version.rb
+++ b/lib/facter/confluence_version.rb
@@ -1,7 +1,7 @@
 Facter.add(:confluence_version) do
   setcode do
     pgrep = Facter::Util::Resolution.exec(
-      'pgrep --list-full --full java.*atlassian-confluence-[0-9].*org.apache.catalina.startup.Bootstrap'
+      'ps ax | grep java.*atlassian-confluence-[0-9].*org.apache.catalina.startup.Bootstrap'
     )
     pgrep.to_s =~ %r{^.*atlassian-confluence-(\d+\.\d+\.\d+).*}
     if Regexp.last_match(1).nil?

--- a/spec/unit/facter/util/fact_confluence_version_spec.rb
+++ b/spec/unit/facter/util/fact_confluence_version_spec.rb
@@ -2,12 +2,12 @@ require 'spec_helper'
 require 'facter/confluence_version'
 
 describe Facter::Util::Fact do
-  pgrep_line = 'pgrep --list-full --full java.*atlassian-confluence-[0-9].*org.apache.catalina.startup.Bootstrap'
+  proc_line = 'ps ax | grep java.*atlassian-confluence-[0-9].*org.apache.catalina.startup.Bootstrap'
   context 'confluence_version with confluence running' do
     before do
       Facter.clear
       Facter.fact(:kernel).stubs(:value).returns('Linux')
-      Facter::Util::Resolution.stubs(:exec).with(pgrep_line).returns('27999 /usr//bin/java -Djava.util.logging.config.file=/opt/confluence/atlassian-confluence-5.7.1/conf/logging.properties -Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager -Xms256m -Xmx1024m -XX:MaxPermSize=256m -Djava.awt.headless=true -Djava.endorsed.dirs=/opt/confluence/atlassian-confluence-5.7.1/endorsed -classpath /opt/confluence/atlassian-confluence-5.7.1/bin/bootstrap.jar:/opt/confluence/atlassian-confluence-5.7.1/bin/tomcat-juli.jar -Dcatalina.base=/opt/confluence/atlassian-confluence-5.7.1 -Dcatalina.home=/opt/confluence/atlassian-confluence-5.7.1 -Djava.io.tmpdir=/opt/confluence/atlassian-confluence-5.7.1/temp org.apache.catalina.startup.Bootstrap start')
+      Facter::Util::Resolution.stubs(:exec).with(proc_line).returns('27999 ?        Sl     4:10 /usr//bin/java -Djava.util.logging.config.file=/opt/confluence/atlassian-confluence-5.7.1/conf/logging.properties -Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager -Xms256m -Xmx1024m -XX:MaxPermSize=256m -Djava.awt.headless=true -Djava.endorsed.dirs=/opt/confluence/atlassian-confluence-5.7.1/endorsed -classpath /opt/confluence/atlassian-confluence-5.7.1/bin/bootstrap.jar:/opt/confluence/atlassian-confluence-5.7.1/bin/tomcat-juli.jar -Dcatalina.base=/opt/confluence/atlassian-confluence-5.7.1 -Dcatalina.home=/opt/confluence/atlassian-confluence-5.7.1 -Djava.io.tmpdir=/opt/confluence/atlassian-confluence-5.7.1/temp org.apache.catalina.startup.Bootstrap start')
     end
     it 'returns the running version' do
       expect(Facter.fact(:confluence_version).value).to eq('5.7.1')
@@ -18,7 +18,7 @@ describe Facter::Util::Fact do
     before do
       Facter.clear
       Facter.fact(:kernel).stubs(:value).returns('Linux')
-      Facter::Util::Resolution.stubs(:exec).with(pgrep_line).returns('27999 /usr/lib/jvm/java-1.8.0-oracle/bin/java -Djava.util.logging.config.file=/opt/confluence/atlassian-confluence-5.7.1/conf/logging.properties -Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager -Xms256m -Xmx1024m -XX:MaxPermSize=256m -Djava.awt.headless=true -Djava.endorsed.dirs=/opt/confluence/atlassian-confluence-5.7.1/endorsed -classpath /opt/confluence/atlassian-confluence-5.7.1/bin/bootstrap.jar:/opt/confluence/atlassian-confluence-5.7.1/bin/tomcat-juli.jar -Dcatalina.base=/opt/confluence/atlassian-confluence-5.7.1 -Dcatalina.home=/opt/confluence/atlassian-confluence-5.7.1 -Djava.io.tmpdir=/opt/confluence/atlassian-confluence-5.7.1/temp org.apache.catalina.startup.Bootstrap start')
+      Facter::Util::Resolution.stubs(:exec).with(proc_line).returns('27999 ?        Sl     4:10 /usr/lib/jvm/java-1.8.0-oracle/bin/java -Djava.util.logging.config.file=/opt/confluence/atlassian-confluence-5.7.1/conf/logging.properties -Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager -Xms256m -Xmx1024m -XX:MaxPermSize=256m -Djava.awt.headless=true -Djava.endorsed.dirs=/opt/confluence/atlassian-confluence-5.7.1/endorsed -classpath /opt/confluence/atlassian-confluence-5.7.1/bin/bootstrap.jar:/opt/confluence/atlassian-confluence-5.7.1/bin/tomcat-juli.jar -Dcatalina.base=/opt/confluence/atlassian-confluence-5.7.1 -Dcatalina.home=/opt/confluence/atlassian-confluence-5.7.1 -Djava.io.tmpdir=/opt/confluence/atlassian-confluence-5.7.1/temp org.apache.catalina.startup.Bootstrap start')
     end
     it 'returns the running version' do
       expect(Facter.fact(:confluence_version).value).to eq('5.7.1')
@@ -29,7 +29,7 @@ describe Facter::Util::Fact do
     before do
       Facter.clear
       Facter.fact(:kernel).stubs(:value).returns('Linux')
-      Facter::Util::Resolution.stubs(:exec).with(pgrep_line).returns('')
+      Facter::Util::Resolution.stubs(:exec).with(proc_line).returns('')
     end
     it 'returns "unknown"' do
       expect(Facter.fact(:confluence_version).value).to eq('unknown')


### PR DESCRIPTION
The long arguments to `pgrep` are not present in older versions of
pgrep, as provided by 'procps'. procps-ng appears to have introduced
these, as used by EL7.

This commit changes the version fact to use `ps ax | grep` to find the
process. It's generic enough and should be supported by the platforms
listed in the module's support matrix.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
