### PR TITLE
Update setenv.sh template

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,10 @@ Increase max permgen size for a Java Virtual Machine. Default: '256m'
 
 Additional java options can be specified here. Default: ''
 
+##### `catalina_opts`
+
+Additional catalina options can be specified here. Default: ''
+
 #### Tomcat parameters
 
 #### `tomcat_proxy`

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,6 +10,7 @@ class confluence (
   $jvm_xmx                                                       = '1024m',
   $jvm_permgen                                                   = '256m',
   $java_opts                                                     = '',
+  String $catalina_opts                                          = '',
   # Confluence Settings
   Pattern[/^(?:(\d+)\.)?(?:(\d+)\.)?(\*|\d+)(|[a-z])$/] $version = '5.7.1',
   $product                                                       = 'confluence',

--- a/templates/setenv.sh.erb
+++ b/templates/setenv.sh.erb
@@ -1,18 +1,6 @@
-#
-# The following 2 settings control the minimum and maximum given to the Confluence Java virtual machine.  In larger Confluence instances, the maximum amount will need to be increased.
-#
-JVM_MINIMUM_MEMORY="<%= scope.lookupvar('confluence::jvm_xms') %>"
-JVM_MAXIMUM_MEMORY="<%= scope.lookupvar('confluence::jvm_xmx') %>"
-JVM_PERMGEN_MEMORY="<%= scope.lookupvar('confluence::jvm_permgen') %>"
+# See the CATALINA_OPTS below for tuning the JVM arguments used to start Confluence.
 
-#
-# Additional JAVA_OPTS
-#
-JAVA_OPTS="<%= scope.lookupvar('confluence::java_opts') %> $JAVA_OPTS"
-JAVA_OPTS="-Xms${JVM_MINIMUM_MEMORY} -Xmx${JVM_MAXIMUM_MEMORY} -XX:MaxPermSize=${JVM_PERMGEN_MEMORY} $JAVA_OPTS -Djava.awt.headless=true "
-export JAVA_OPTS
-
-echo "If you encounter issues starting up Confluence Standalone, please see the Installation guide at http://confluence.atlassian.com/display/DOC/Confluence+Installation+Guide"
+echo "If you encounter issues starting up Confluence, please see the Installation guide at http://confluence.atlassian.com/display/DOC/Confluence+Installation+Guide"
 
 # set the location of the pid file
 if [ -z "$CATALINA_PID" ] ; then
@@ -46,3 +34,62 @@ cd $PUSHED_DIR
 
 echo ""
 echo "Server startup logs are located in $LOGBASEABS/logs/catalina.out"
+
+<%- if scope['confluence::version'] =~ /^6/ -%>
+# IMPORTANT NOTE: Only set JAVA_HOME or JRE_HOME above this line
+# Get standard Java environment variables
+if $os400; then
+  # -r will Only work on the os400 if the files are:
+  # 1. owned by the user
+  # 2. owned by the PRIMARY group of the user
+  # this will not work if the user belongs in secondary groups
+  . "$CATALINA_HOME"/bin/setjre.sh
+else
+  if [ -r "$CATALINA_HOME"/bin/setjre.sh ]; then
+    . "$CATALINA_HOME"/bin/setjre.sh
+  else
+    echo "Cannot find $CATALINA_HOME/bin/setjre.sh"
+    echo "This file is needed to run this program"
+    exit 1
+  fi
+fi
+
+echo "---------------------------------------------------------------------------"
+echo "Using Java: $JRE_HOME/bin/java"
+CONFLUENCE_CONTEXT_PATH=`$JRE_HOME/bin/java -jar $CATALINA_HOME/bin/confluence-context-path-extractor.jar $CATALINA_HOME`
+export CONFLUENCE_CONTEXT_PATH
+$JRE_HOME/bin/java -jar $CATALINA_HOME/bin/synchrony-proxy-watchdog.jar $CATALINA_HOME
+echo "---------------------------------------------------------------------------"
+<%- end -%>
+
+# The following 2 settings control the minimum and maximum given to the Confluence Java virtual machine.  In larger Confluence instances, the maximum amount will need to be increased.
+#
+JVM_MINIMUM_MEMORY="<%= scope['confluence::jvm_xms'] %>"
+JVM_MAXIMUM_MEMORY="<%= scope['confluence::jvm_xmx'] %>"
+JVM_PERMGEN_MEMORY="<%= scope['confluence::jvm_permgen'] %>"
+
+#
+# Additional JAVA_OPTS
+#
+JAVA_OPTS="<%= scope['confluence::java_opts'] %> $JAVA_OPTS"
+export JAVA_OPTS
+
+# Set the JVM arguments used to start Confluence. For a description of the options, see
+# http://www.oracle.com/technetwork/java/javase/tech/vmoptions-jsp-140102.html
+CATALINA_OPTS="<%= scope['confluence::catalina_opts'] %> ${CATALINA_OPTS}"
+CATALINA_OPTS="-XX:-PrintGCDetails -XX:+PrintGCDateStamps -XX:-PrintTenuringDistribution ${CATALINA_OPTS}"
+CATALINA_OPTS="-Xloggc:$LOGBASEABS/logs/gc-`date +%F_%H-%M-%S`.log -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=5 -XX:GCLogFileSize=2M ${CATALINA_OPTS}"
+CATALINA_OPTS="-Djava.awt.headless=true ${CATALINA_OPTS}"
+CATALINA_OPTS="-Xms${JVM_MINIMUM_MEMORY} -Xmx${JVM_MAXIMUM_MEMORY} -XX:+UseG1GC ${CATALINA_OPTS}"
+
+<%- if scope['confluence::version'] =~ /^6/ -%>
+CATALINA_OPTS="-XX:G1ReservePercent=20 ${CATALINA_OPTS}"
+CATALINA_OPTS="-Datlassian.plugins.enable.wait=300 ${CATALINA_OPTS}"
+CATALINA_OPTS="-Dsynchrony.enable.xhr.fallback=true ${CATALINA_OPTS}"
+CATALINA_OPTS="-Dorg.apache.tomcat.websocket.DEFAULT_BUFFER_SIZE=32768 ${CATALINA_OPTS}"
+CATALINA_OPTS="${START_CONFLUENCE_JAVA_OPTS} ${CATALINA_OPTS}"
+CATALINA_OPTS="-Dconfluence.context.path=${CONFLUENCE_CONTEXT_PATH} ${CATALINA_OPTS}"
+<%- elsif scope['confluence::version'] =~ /^5/ -%>
+CATALINA_OPTS="-XX:MaxPermSize=${JVM_PERMGEN_MEMORY} ${CATALINA_OPTS}"
+<%- end -%>
+export CATALINA_OPTS


### PR DESCRIPTION
The setenv.sh template, while functional, appeared to be a bit old and
lacking some updated conventions Atlassian's been using in the setenv.sh
script for at least a couple of years (such as CATALINA_OPTS).

Most importantly, there's some new additions to it to support Confluence
6 and its synchrony service.

This preserves the `JAVA_OPTS` to be backwards compatible, but does
move to use `CATALINA_OPTS`, as has been used by Atlassian out of the
box for some time, and introduces a `catalina_opts` parameter.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
