### PR TITLE
use systemd on Debian 8 (jessie) and later

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,40 +9,29 @@ class confluence::params {
       if $facts['os']['release']['major'] == '7' {
         $service_file_location = '/usr/lib/systemd/system/confluence.service'
         $service_file_template = 'confluence/confluence.service.erb'
-        $service_lockfile      = '/var/lock/subsys/confluence'
         $refresh_systemd       = true
       } elsif $facts['os']['release']['major'] == '6' {
         $service_file_location = '/etc/init.d/confluence'
         $service_file_template = 'confluence/confluence.initscript.erb'
-        $service_lockfile      = '/var/lock/subsys/confluence'
         $refresh_systemd       = false
       } else {
         fail("Only osfamily ${facts['os']['family']} 6 and 7 and supported")
       }
     }
     /Debian/: {
-      case $facts['os']['name'] {
-        /Ubuntu/: {
-          case $facts['os']['release']['major'] {
-            /^16.04$/: {
-              $service_file_location   = '/etc/systemd/system/confluence.service'
-              $service_file_template   = 'confluence/confluence.service.erb'
-              $service_lockfile        = '/var/lock/subsys/confluence'
-              $refresh_systemd         = true
-            }
-            default: {
-              $service_file_location   = '/etc/init.d/confluence'
-              $service_file_template   = 'confluence/confluence.initscript.erb'
-              $service_lockfile        = '/var/lock/confluence'
-              $refresh_systemd         = false
-            }
-          }
+      case $facts['service_provider'] {
+        'systemd': {
+          $service_file_location = '/etc/systemd/system/confluence.service'
+          $service_file_template = 'confluence/confluence.service.erb'
+          $refresh_systemd       = true
+        }
+        'debian': {
+          $service_file_location = '/etc/init.d/confluence'
+          $service_file_template = 'confluence/confluence.initscript.erb'
+          $refresh_systemd       = false
         }
         default: {
-          $service_file_location   = '/etc/init.d/confluence'
-          $service_file_template   = 'confluence/confluence.initscript.erb'
-          $service_lockfile        = '/var/lock/confluence'
-          $refresh_systemd         = false
+          fail("Unsupported service provider ${facts['service_provider']}")
         }
       }
     }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -5,7 +5,6 @@
 class confluence::service (
   $service_file_location = $confluence::params::service_file_location,
   $service_file_template = $confluence::params::service_file_template,
-  $service_lockfile      = $confluence::params::service_lockfile,
   $refresh_systemd       = $confluence::params::refresh_systemd,
 ) {
 


### PR DESCRIPTION
Debian 8 switched to systemd by default, this PR adds a params block specifically for Debian which switches to systemd if the OS major version is 8 or above.