### PR TITLE
removed dependency on camptocamp/systemd

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -5,4 +5,3 @@ fixtures:
     archive: "https://github.com/voxpupuli/puppet-archive.git"
     staging: "https://github.com/voxpupuli/puppet-staging.git"
     stdlib:  "https://github.com/puppetlabs/puppetlabs-stdlib.git"
-    systemd: "https://github.com/camptocamp/puppet-systemd.git"

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -10,18 +10,17 @@ class confluence::service (
 ) {
 
   if($refresh_systemd) {
-    include ::systemd::systemctl::daemon_reload
+    exec { 'refresh_systemd_confluence':
+      command     => 'systemctl daemon-reload',
+      refreshonly => true,
+      subscribe   => File[$service_file_location],
+      before      => Service['confluence'],
+    }
   }
 
   file { $service_file_location:
     content => template($service_file_template),
     mode    => '0755',
-    notify  => [
-      $refresh_systemd ? {
-        true    => Class['systemd::systemctl::daemon_reload'],
-        default => undef
-      }
-    ],
   }
 
   if $confluence::manage_service {

--- a/metadata.json
+++ b/metadata.json
@@ -10,10 +10,6 @@
   "description": "Atlassian confluence",
   "dependencies": [
     {
-      "name": "camptocamp/systemd",
-      "version_requirement": ">= 1.0.0 < 2.0.0"
-    },
-    {
       "name": "puppet/archive",
       "version_requirement": ">= 1.0.0 < 3.0.0"
     },

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -40,7 +40,6 @@ RSpec.configure do |c|
       on host, puppet('module', 'install', 'puppetlabs-postgresql'), acceptable_exit_codes: [0, 1]
       on host, puppet('module', 'install', 'puppet-staging'), acceptable_exit_codes: [0, 1]
       on host, puppet('module', 'install', 'puppetlabs-stdlib'), acceptable_exit_codes: [0, 1]
-      on host, puppet('module', 'install', 'camptocamp-systemd'), acceptable_exit_codes: [0, 1]
     end
   end
 end


### PR DESCRIPTION
In our organisation we use the ```eyp/systemd``` to generate systemd unit files. This conflicts with the use of ```camptocamp/systemd``` in this module, which seems to be just used for running a daemon-reload command.

This PR copies the strategy of the ```puppet/jira``` module and uses an exec instead of depending on a third-party module.