### PR TITLE
Update setenv.sh to support CATALINA_OPTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,9 @@ confluence::jvm_xms:        '4G'
 confluence::jvm_xmx:        '8G'
 confluence::jvm_permgen:    '512m'
 confluence::download_url:    'http://webserver.example.co.za/pub/software/development-tools/atlassian'
+confluence::catalina_opts:
+  - -Dconfluence.cluster.node.name=%{hostname}
+  - -Dconfluence.upgrade.recovery.file.enabled=false
 confluence::tomcat_proxy:
   scheme:    'https'
   proxyName: 'webvip.example.co.za'
@@ -226,7 +229,7 @@ Additional java options can be specified here. Default: ''
 
 ##### `catalina_opts`
 
-Additional catalina options can be specified here. Default: ''
+Additional catalina options can be specified either as a simple string or array of strings. Default: ''
 
 #### Tomcat parameters
 

--- a/README.md
+++ b/README.md
@@ -224,6 +224,10 @@ Increase max permgen size for a Java Virtual Machine. Default: '256m'
 
 Additional java options can be specified here. Default: ''
 
+##### `catalina_opts`
+
+Additional catalina options can be specified here. Default: ''
+
 #### Tomcat parameters
 
 #### `tomcat_proxy`

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,6 +10,7 @@ class confluence (
   $jvm_xmx                                                       = '1024m',
   $jvm_permgen                                                   = '256m',
   $java_opts                                                     = '',
+  String $catalina_opts                                          = '',
   # Confluence Settings
   Pattern[/^(?:(\d+)\.)?(?:(\d+)\.)?(\*|\d+)(|[a-z])$/] $version = '5.7.1',
   $product                                                       = 'confluence',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,7 +10,7 @@ class confluence (
   $jvm_xmx                                                       = '1024m',
   $jvm_permgen                                                   = '256m',
   $java_opts                                                     = '',
-  String $catalina_opts                                          = '',
+  Variant[String,Array[String]] $catalina_opts                   = '',
   # Confluence Settings
   Pattern[/^(?:(\d+)\.)?(?:(\d+)\.)?(\*|\d+)(|[a-z])$/] $version = '5.7.1',
   $product                                                       = 'confluence',

--- a/spec/classes/confluence_config_spec.rb
+++ b/spec/classes/confluence_config_spec.rb
@@ -126,6 +126,39 @@ describe 'confluence' do
               with_content(%r{<Connector enableLookups="false" URIEncoding="UTF-8"\s+port = "8009"\s+protocol = "AJP/1.3"\s+/>})
           end
         end
+
+        context 'catalina_opts set to a string' do
+          let(:params) do
+            {
+              version: '6.12.0',
+              javahome: '/opt/java',
+              catalina_opts: '-Dconfluence.upgrade.recovery.file.enabled=false -Dconfluence.cluster.node.name=myhostname'
+            }
+          end
+
+          it do
+            is_expected.to compile.with_all_deps
+            is_expected.to contain_file('/opt/confluence/atlassian-confluence-6.12.0/bin/setenv.sh').
+              with_content(%r{CATALINA_OPTS=\"-Dconfluence.upgrade.recovery.file.enabled=false -Dconfluence.cluster.node.name=myhostname \${CATALINA_OPTS}\"})
+          end
+        end
+
+        context 'catalina_opts set to an array' do
+          let(:params) do
+            {
+              version: '6.12.0',
+              javahome: '/opt/java',
+              catalina_opts: ['-Dconfluence.upgrade.recovery.file.enabled=false', '-Dconfluence.cluster.node.name=myhostname']
+            }
+          end
+
+          it do
+            is_expected.to compile.with_all_deps
+            is_expected.to contain_file('/opt/confluence/atlassian-confluence-6.12.0/bin/setenv.sh').
+              with_content(%r{CATALINA_OPTS=\"-Dconfluence.upgrade.recovery.file.enabled=false \${CATALINA_OPTS}\"}).
+              with_content(%r{CATALINA_OPTS=\"-Dconfluence.cluster.node.name=myhostname \${CATALINA_OPTS}\"})
+          end
+        end
       end
     end
   end

--- a/templates/setenv.sh.erb
+++ b/templates/setenv.sh.erb
@@ -1,18 +1,6 @@
-#
-# The following 2 settings control the minimum and maximum given to the Confluence Java virtual machine.  In larger Confluence instances, the maximum amount will need to be increased.
-#
-JVM_MINIMUM_MEMORY="<%= scope.lookupvar('confluence::jvm_xms') %>"
-JVM_MAXIMUM_MEMORY="<%= scope.lookupvar('confluence::jvm_xmx') %>"
-JVM_PERMGEN_MEMORY="<%= scope.lookupvar('confluence::jvm_permgen') %>"
+# See the CATALINA_OPTS below for tuning the JVM arguments used to start Confluence.
 
-#
-# Additional JAVA_OPTS
-#
-JAVA_OPTS="<%= scope.lookupvar('confluence::java_opts') %> $JAVA_OPTS"
-JAVA_OPTS="-Xms${JVM_MINIMUM_MEMORY} -Xmx${JVM_MAXIMUM_MEMORY} -XX:MaxPermSize=${JVM_PERMGEN_MEMORY} $JAVA_OPTS -Djava.awt.headless=true "
-export JAVA_OPTS
-
-echo "If you encounter issues starting up Confluence Standalone, please see the Installation guide at http://confluence.atlassian.com/display/DOC/Confluence+Installation+Guide"
+echo "If you encounter issues starting up Confluence, please see the Installation guide at http://confluence.atlassian.com/display/DOC/Confluence+Installation+Guide"
 
 # set the location of the pid file
 if [ -z "$CATALINA_PID" ] ; then
@@ -46,3 +34,62 @@ cd $PUSHED_DIR
 
 echo ""
 echo "Server startup logs are located in $LOGBASEABS/logs/catalina.out"
+
+<%- if scope['confluence::version'] =~ /^6/ -%>
+# IMPORTANT NOTE: Only set JAVA_HOME or JRE_HOME above this line
+# Get standard Java environment variables
+if $os400; then
+  # -r will Only work on the os400 if the files are:
+  # 1. owned by the user
+  # 2. owned by the PRIMARY group of the user
+  # this will not work if the user belongs in secondary groups
+  . "$CATALINA_HOME"/bin/setjre.sh
+else
+  if [ -r "$CATALINA_HOME"/bin/setjre.sh ]; then
+    . "$CATALINA_HOME"/bin/setjre.sh
+  else
+    echo "Cannot find $CATALINA_HOME/bin/setjre.sh"
+    echo "This file is needed to run this program"
+    exit 1
+  fi
+fi
+
+echo "---------------------------------------------------------------------------"
+echo "Using Java: $JRE_HOME/bin/java"
+CONFLUENCE_CONTEXT_PATH=`$JRE_HOME/bin/java -jar $CATALINA_HOME/bin/confluence-context-path-extractor.jar $CATALINA_HOME`
+export CONFLUENCE_CONTEXT_PATH
+$JRE_HOME/bin/java -jar $CATALINA_HOME/bin/synchrony-proxy-watchdog.jar $CATALINA_HOME
+echo "---------------------------------------------------------------------------"
+<%- end -%>
+
+# The following 2 settings control the minimum and maximum given to the Confluence Java virtual machine.  In larger Confluence instances, the maximum amount will need to be increased.
+#
+JVM_MINIMUM_MEMORY="<%= scope['confluence::jvm_xms'] %>"
+JVM_MAXIMUM_MEMORY="<%= scope['confluence::jvm_xmx'] %>"
+JVM_PERMGEN_MEMORY="<%= scope['confluence::jvm_permgen'] %>"
+
+#
+# Additional JAVA_OPTS
+#
+JAVA_OPTS="<%= scope['confluence::java_opts'] %> $JAVA_OPTS"
+export JAVA_OPTS
+
+# Set the JVM arguments used to start Confluence. For a description of the options, see
+# http://www.oracle.com/technetwork/java/javase/tech/vmoptions-jsp-140102.html
+CATALINA_OPTS="<%= scope['confluence::catalina_opts'] %> ${CATALINA_OPTS}"
+CATALINA_OPTS="-XX:-PrintGCDetails -XX:+PrintGCDateStamps -XX:-PrintTenuringDistribution ${CATALINA_OPTS}"
+CATALINA_OPTS="-Xloggc:$LOGBASEABS/logs/gc-`date +%F_%H-%M-%S`.log -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=5 -XX:GCLogFileSize=2M ${CATALINA_OPTS}"
+CATALINA_OPTS="-Djava.awt.headless=true ${CATALINA_OPTS}"
+CATALINA_OPTS="-Xms${JVM_MINIMUM_MEMORY} -Xmx${JVM_MAXIMUM_MEMORY} -XX:+UseG1GC ${CATALINA_OPTS}"
+
+<%- if scope['confluence::version'] =~ /^6/ -%>
+CATALINA_OPTS="-XX:G1ReservePercent=20 ${CATALINA_OPTS}"
+CATALINA_OPTS="-Datlassian.plugins.enable.wait=300 ${CATALINA_OPTS}"
+CATALINA_OPTS="-Dsynchrony.enable.xhr.fallback=true ${CATALINA_OPTS}"
+CATALINA_OPTS="-Dorg.apache.tomcat.websocket.DEFAULT_BUFFER_SIZE=32768 ${CATALINA_OPTS}"
+CATALINA_OPTS="${START_CONFLUENCE_JAVA_OPTS} ${CATALINA_OPTS}"
+CATALINA_OPTS="-Dconfluence.context.path=${CONFLUENCE_CONTEXT_PATH} ${CATALINA_OPTS}"
+<%- elsif scope['confluence::version'] =~ /^5/ -%>
+CATALINA_OPTS="-XX:MaxPermSize=${JVM_PERMGEN_MEMORY} ${CATALINA_OPTS}"
+<%- end -%>
+export CATALINA_OPTS

--- a/templates/setenv.sh.erb
+++ b/templates/setenv.sh.erb
@@ -1,3 +1,5 @@
+### THIS FILE IS MANAGED BY PUPPET - ANY MANUAL CHANGES WILL BE LOST!
+<%- version = scope['confluence::version'].split('.').map(&:to_i) # splits version string into integers -%>
 # See the CATALINA_OPTS below for tuning the JVM arguments used to start Confluence.
 
 echo "If you encounter issues starting up Confluence, please see the Installation guide at http://confluence.atlassian.com/display/DOC/Confluence+Installation+Guide"
@@ -34,8 +36,8 @@ cd $PUSHED_DIR
 
 echo ""
 echo "Server startup logs are located in $LOGBASEABS/logs/catalina.out"
+<%- if version[0] >= 6 and version[1] >= 1 # version 6.1 or greater -%>
 
-<%- if scope['confluence::version'] =~ /^6/ -%>
 # IMPORTANT NOTE: Only set JAVA_HOME or JRE_HOME above this line
 # Get standard Java environment variables
 if $os400; then
@@ -61,6 +63,7 @@ export CONFLUENCE_CONTEXT_PATH
 $JRE_HOME/bin/java -jar $CATALINA_HOME/bin/synchrony-proxy-watchdog.jar $CATALINA_HOME
 echo "---------------------------------------------------------------------------"
 <%- end -%>
+<%- if version[0] < 5 # prior to version 5.x? -%>
 
 # The following 2 settings control the minimum and maximum given to the Confluence Java virtual machine.  In larger Confluence instances, the maximum amount will need to be increased.
 #
@@ -73,23 +76,43 @@ JVM_PERMGEN_MEMORY="<%= scope['confluence::jvm_permgen'] %>"
 #
 JAVA_OPTS="<%= scope['confluence::java_opts'] %> $JAVA_OPTS"
 export JAVA_OPTS
+<%- end -%>
+<%- if version[0] >= 5 -%>
 
 # Set the JVM arguments used to start Confluence. For a description of the options, see
 # http://www.oracle.com/technetwork/java/javase/tech/vmoptions-jsp-140102.html
-CATALINA_OPTS="<%= scope['confluence::catalina_opts'] %> ${CATALINA_OPTS}"
 CATALINA_OPTS="-XX:-PrintGCDetails -XX:+PrintGCDateStamps -XX:-PrintTenuringDistribution ${CATALINA_OPTS}"
 CATALINA_OPTS="-Xloggc:$LOGBASEABS/logs/gc-`date +%F_%H-%M-%S`.log -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=5 -XX:GCLogFileSize=2M ${CATALINA_OPTS}"
-CATALINA_OPTS="-Djava.awt.headless=true ${CATALINA_OPTS}"
-CATALINA_OPTS="-Xms${JVM_MINIMUM_MEMORY} -Xmx${JVM_MAXIMUM_MEMORY} -XX:+UseG1GC ${CATALINA_OPTS}"
-
-<%- if scope['confluence::version'] =~ /^6/ -%>
 CATALINA_OPTS="-XX:G1ReservePercent=20 ${CATALINA_OPTS}"
+CATALINA_OPTS="-Djava.awt.headless=true ${CATALINA_OPTS}"
 CATALINA_OPTS="-Datlassian.plugins.enable.wait=300 ${CATALINA_OPTS}"
+CATALINA_OPTS="-Xms<%= scope['confluence::jvm_xms'] %> -Xmx<%= scope['confluence::jvm_xmx'] %> -XX:+UseG1GC ${CATALINA_OPTS}"
+<%-   if version[0] >= 6 # 6.x.x or higher -%>
+<%-     if version[1] >= 1 # 6.1.x or higher -%>
 CATALINA_OPTS="-Dsynchrony.enable.xhr.fallback=true ${CATALINA_OPTS}"
+<%-     end -%>
 CATALINA_OPTS="-Dorg.apache.tomcat.websocket.DEFAULT_BUFFER_SIZE=32768 ${CATALINA_OPTS}"
+<%-     if version[1] >= 1 # 6.1.x or higher -%>
 CATALINA_OPTS="${START_CONFLUENCE_JAVA_OPTS} ${CATALINA_OPTS}"
+<%-     end -%>
 CATALINA_OPTS="-Dconfluence.context.path=${CONFLUENCE_CONTEXT_PATH} ${CATALINA_OPTS}"
-<%- elsif scope['confluence::version'] =~ /^5/ -%>
+<%-     if version[1] >= 8 # 6.8.x or higher -%>
+CATALINA_OPTS="-XX:ReservedCodeCacheSize=256m -XX:+UseCodeCacheFlushing ${CATALINA_OPTS}"
+<%-     end -%>
+<%-   end -%>
+<%-   if scope['confluence::version'].is_a?(String) and !scope['confluence::version'].empty? -%>
 CATALINA_OPTS="-XX:MaxPermSize=${JVM_PERMGEN_MEMORY} ${CATALINA_OPTS}"
-<%- end -%>
+<%-   end -%>
+<%- catalina_opts = scope['confluence::catalina_opts'] -%>
+<%-   if catalina_opts.is_a?(Array) # add each option as its own line -%>
+<%-     catalina_opts.each do |opt| -%>
+CATALINA_OPTS="<%= opt %> ${CATALINA_OPTS}"
+<%-     end -%>
+<%-   elsif catalina_opts.is_a?(String) && !catalina_opts.empty? # add catalina_opts -%>
+CATALINA_OPTS="<%= catalina_opts %> ${CATALINA_OPTS}"
+<%-   end -%>
+
+
 export CATALINA_OPTS
+<%- end # if version[0] >= 5 -%>
+

--- a/templates/setenv.sh.erb
+++ b/templates/setenv.sh.erb
@@ -100,8 +100,8 @@ CATALINA_OPTS="-Dconfluence.context.path=${CONFLUENCE_CONTEXT_PATH} ${CATALINA_O
 CATALINA_OPTS="-XX:ReservedCodeCacheSize=256m -XX:+UseCodeCacheFlushing ${CATALINA_OPTS}"
 <%-     end -%>
 <%-   end -%>
-<%-   if scope['confluence::version'].is_a?(String) and !scope['confluence::version'].empty? -%>
-CATALINA_OPTS="-XX:MaxPermSize=${JVM_PERMGEN_MEMORY} ${CATALINA_OPTS}"
+<%-   if version[0] == 5 and version[1] <= 7 # 5.7.x and below -%>
+CATALINA_OPTS="-XX:MaxPermSize=<%= scope['confluence::jvm_permgen'] %> ${CATALINA_OPTS}"
 <%-   end -%>
 <%- catalina_opts = scope['confluence::catalina_opts'] -%>
 <%-   if catalina_opts.is_a?(Array) # add each option as its own line -%>


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

Updates to setenv.sh support CATALINA_OPTS

    * Continuation of PR #140 (@joshbeard)
    * Support CATALINA_OPTS either as a string or array of strings
    * These changes should support making the setenv.sh with minimal changes
        from 6.0.x (which is EOL soon) to 6.12.x which was just released.
    * Change so the "JAVA_OPTS" part only appear for version prior to Confluence 5.x
    * Update README for types and to have an example


#### This Pull Request (PR) fixes the following issues

* Fixes #155 
* Continue PR #140 (take over)

