### PR TITLE
drop dependency on camptocamp/systemd

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -9,19 +9,22 @@ class confluence::service (
   $refresh_systemd       = $confluence::params::refresh_systemd,
 ) {
 
-  if($refresh_systemd) {
-    include ::systemd::systemctl::daemon_reload
-  }
-
   file { $service_file_location:
     content => template($service_file_template),
     mode    => '0755',
     notify  => [
       $refresh_systemd ? {
-        true    => Class['systemd::systemctl::daemon_reload'],
+        true    => Exec["${title}-systemd-reload"],
         default => undef
       }
     ],
+  }
+
+  # Reload systemd
+  exec { "${title}-systemd-reload":
+    command     => 'systemctl daemon-reload',
+    path        => [ '/usr/bin', '/bin', '/usr/sbin' ],
+    refreshonly => true,
   }
 
   if $confluence::manage_service {

--- a/metadata.json
+++ b/metadata.json
@@ -10,10 +10,6 @@
   "description": "Atlassian confluence",
   "dependencies": [
     {
-      "name": "camptocamp/systemd",
-      "version_requirement": ">= 1.0.0 < 3.0.0"
-    },
-    {
       "name": "puppet/archive",
       "version_requirement": ">= 1.0.0 < 4.0.0"
     },

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -40,7 +40,6 @@ RSpec.configure do |c|
       on host, puppet('module', 'install', 'puppetlabs-postgresql'), acceptable_exit_codes: [0, 1]
       on host, puppet('module', 'install', 'puppet-staging'), acceptable_exit_codes: [0, 1]
       on host, puppet('module', 'install', 'puppetlabs-stdlib'), acceptable_exit_codes: [0, 1]
-      on host, puppet('module', 'install', 'camptocamp-systemd'), acceptable_exit_codes: [0, 1]
     end
   end
 end


### PR DESCRIPTION
#### Pull Request (PR) description
Currently this module depends on camptocamp/systemd, but it's only used for a **single** call to systemctl. A downside of using this dependency is that it may conflict with other systemd modules.

This PR replaces the need for camptocamp/systemd with a simple `Exec`.