### PR TITLE
replace deprecated has_key() with `in`

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -93,12 +93,12 @@ class confluence (
     if $manage_server_xml != 'template' {
       fail('An AJP connector can only be configured with manage_server_xml = template.')
     }
-    if ! has_key($ajp, 'port') {
+    if ! ('port' in $ajp) {
       fail('You need to specify a valid port for the AJP connector.')
     } else {
       assert_type(Variant[Pattern[/^\d+$/], Stdlib::Port], $ajp['port'])
     }
-    if ! has_key($ajp, 'protocol') {
+    if ! ('protocol' in $ajp) {
       fail('You need to specify a valid protocol for the AJP connector.')
     } else {
       assert_type(Enum['AJP/1.3', 'org.apache.coyote.ajp'], $ajp['protocol'])


### PR DESCRIPTION
We could have changed the `if !` to unless, but there is also an `else`
part. Unless with else always looks strange to me and isn't supported in
all Puppet versions, so I kept the `if !`.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
    Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
    Replace this comment with the list of issues or n/a.
    Use format:
    Fixes #123
    Fixes #124
-->
