### PR TITLE
Debian support

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,40 +9,29 @@ class confluence::params {
       if $facts['os']['release']['major'] == '7' {
         $service_file_location = '/usr/lib/systemd/system/confluence.service'
         $service_file_template = 'confluence/confluence.service.erb'
-        $service_lockfile      = '/var/lock/subsys/confluence'
         $refresh_systemd       = true
       } elsif $facts['os']['release']['major'] == '6' {
         $service_file_location = '/etc/init.d/confluence'
         $service_file_template = 'confluence/confluence.initscript.erb'
-        $service_lockfile      = '/var/lock/subsys/confluence'
         $refresh_systemd       = false
       } else {
         fail("Only osfamily ${facts['os']['family']} 6 and 7 and supported")
       }
     }
     /Debian/: {
-      case $facts['os']['name'] {
-        /Ubuntu/: {
-          case $facts['os']['release']['major'] {
-            /^16.04$/: {
-              $service_file_location   = '/etc/systemd/system/confluence.service'
-              $service_file_template   = 'confluence/confluence.service.erb'
-              $service_lockfile        = '/var/lock/subsys/confluence'
-              $refresh_systemd         = true
-            }
-            default: {
-              $service_file_location   = '/etc/init.d/confluence'
-              $service_file_template   = 'confluence/confluence.initscript.erb'
-              $service_lockfile        = '/var/lock/confluence'
-              $refresh_systemd         = false
-            }
-          }
+      case $facts['service_provider'] {
+        'systemd': {
+          $service_file_location = '/etc/systemd/system/confluence.service'
+          $service_file_template = 'confluence/confluence.service.erb'
+          $refresh_systemd       = true
+        }
+        'debian': {
+          $service_file_location = '/etc/init.d/confluence'
+          $service_file_template = 'confluence/confluence.initscript.erb'
+          $refresh_systemd       = false
         }
         default: {
-          $service_file_location   = '/etc/init.d/confluence'
-          $service_file_template   = 'confluence/confluence.initscript.erb'
-          $service_lockfile        = '/var/lock/confluence'
-          $refresh_systemd         = false
+          fail("Unsupported service provider ${facts['service_provider']}")
         }
       }
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -25,13 +25,10 @@ class confluence::params {
           $service_file_template = 'confluence/confluence.service.erb'
           $refresh_systemd       = true
         }
-        'debian': {
+        default: {
           $service_file_location = '/etc/init.d/confluence'
           $service_file_template = 'confluence/confluence.initscript.erb'
           $refresh_systemd       = false
-        }
-        default: {
-          fail("Unsupported service provider ${facts['service_provider']}")
         }
       }
     }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -5,7 +5,6 @@
 class confluence::service (
   $service_file_location = $confluence::params::service_file_location,
   $service_file_template = $confluence::params::service_file_template,
-  $service_lockfile      = $confluence::params::service_lockfile,
   $refresh_systemd       = $confluence::params::refresh_systemd,
 ) {
 

--- a/spec/classes/confluence_params_spec.rb
+++ b/spec/classes/confluence_params_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper.rb'
+
+describe 'confluence' do
+  describe 'confluence::params' do
+    on_supported_os.each do |os, fs_facts|
+      context "on #{os}" do
+        let :facts do
+          fs_facts
+        end
+
+        context 'default params' do
+          let(:params) do
+            {
+              javahome: '/opt/java',
+              version: '5.5.6'
+            }
+          end
+
+          case os
+          when 'centos-6-x86_64', 'redhat-6-x86_64', 'ubuntu-14.04-x86_64', 'debian-7-x86_64'
+            it { is_expected.to contain_file('/etc/init.d/confluence') }
+          when 'centos-7-x86_64', 'redhat-7-x86_64'
+            it { is_expected.to contain_file('/usr/lib/systemd/system/confluence.service') }
+          when 'ubuntu-16.04-x86_64', 'ubuntu-18.04-x86_64', 'debian-8-x86_64', 'debian-9-x86_64'
+            it { is_expected.to contain_file('/etc/systemd/system/confluence.service') }
+          end
+
+          it { is_expected.to compile.with_all_deps }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### Pull Request (PR) description
Patch [PR 147](https://github.com/voxpupuli/puppet-confluence/pull/147) to pass unit tests, as a start on supporting Debian 8/9. Default to init.d script for debian systems when systemd is not found, previous PR failed on Ubuntu 14.04 because the behavior for upstart (i.e., it died) was incorrect.