### PR TITLE
Feature/support eyp

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,14 @@ Only supported with `deploy_module => archive` (the default).  Defaults to 'unde
 
 Should puppet manage this service? Default: true
 
+##### `service_nofile`
+
+Set maximum number of files for confluence service
+
+##### `service_nproc`
+
+Set maximum number of processes for confluence service
+
 ##### `deploy_module`
 
 Module to use for downloading and extracting archive file. Supports

--- a/README.md
+++ b/README.md
@@ -345,6 +345,10 @@ paramater can be used to shut down confluence for upgrades. Defaults to
 
 Enable external facts for confluence version. Defaults to present.
 
+##### `systemd_module`
+
+Choose which systemd module you'd like to use to control the Confluence service. Defaults to 'camptocamp'.
+
 ## Limitations
 
 * Puppet 4.10.0

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -61,6 +61,7 @@ class confluence (
   $session_lastvalidation                                        = 'session.lastvalidation',
   $proxy_server                                                  = undef,
   $proxy_type                                                    = undef,
+  $systemd_module                                                = 'camptocamp',
 ) inherits confluence::params {
 
   Exec { path => [ '/bin/', '/sbin/' , '/usr/bin/', '/usr/sbin/' ] }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -31,6 +31,8 @@ class confluence (
   $deploy_module                                                 = 'archive',
   # Manage confluence server
   $manage_service                                                = true,
+  $service_nofile                                                = undef,
+  $service_nproc                                                 = undef,
   # Tomcat Tunables
   # Should we use augeas to manage server.xml or a template file
   Enum['augeas', 'template'] $manage_server_xml                  = 'augeas',

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -44,17 +44,6 @@ class confluence::service (
       execstart   => "${confluence::webappdir}/bin/start-confluence.sh",
       execstop    => "${confluence::webappdir}/bin/stop-confluence.sh",
       env_vars    => [ "\"JAVA_HOME=${confluence::javahome}\"" ],
-      notify      => [
-        $refresh_systemd ? {
-          true    => Exec['reload_systemd_for_confluence'],
-          default => undef
-        }
-      ],
-    }
-
-    exec { 'reload_systemd_for_confluence':
-      command     => 'systemctl daemon-reload',
-      refreshonly => true,
     }
 
     if $confluence::manage_service {

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -9,26 +9,61 @@ class confluence::service (
   $refresh_systemd       = $confluence::params::refresh_systemd,
 ) {
 
-  if($refresh_systemd) {
-    include ::systemd::systemctl::daemon_reload
-  }
+  if $confluence::systemd_module == 'camptocamp' {
+    if($refresh_systemd) {
+      include systemd::systemctl::daemon_reload
+    }
 
-  file { $service_file_location:
-    content => template($service_file_template),
-    mode    => '0755',
-    notify  => [
-      $refresh_systemd ? {
-        true    => Class['systemd::systemctl::daemon_reload'],
-        default => undef
+    file { $service_file_location:
+      content => template($service_file_template),
+      mode    => '0755',
+      notify  => [
+        $refresh_systemd ? {
+          true    => Class['systemd::systemctl::daemon_reload'],
+          default => undef
+        }
+      ],
+    }
+
+    if $confluence::manage_service {
+      service { 'confluence':
+        ensure  => 'running',
+        enable  => true,
+        require => [ Class['confluence::config'], File[$service_file_location], ],
       }
-    ],
-  }
-
-  if $confluence::manage_service {
-    service { 'confluence':
-      ensure  => 'running',
-      enable  => true,
-      require => [ Class['confluence::config'], File[$service_file_location], ],
     }
   }
+
+  if $confluence::systemd_module == 'eyp' {
+    systemd::service { 'confluence':
+      description => 'Confluence Team Collaboration Software',
+      after       => 'network.target',
+      user        => $confluence::user,
+      group       => $confluence::group,
+      forking     => true,
+      execstart   => "${confluence::webappdir}/bin/start-confluence.sh",
+      execstop    => "${confluence::webappdir}/bin/stop-confluence.sh",
+      env_vars    => [ "\"JAVA_HOME=${confluence::javahome}\"" ],
+      notify      => [
+        $refresh_systemd ? {
+          true    => Exec['reload_systemd_for_confluence'],
+          default => undef
+        }
+      ],
+    }
+
+    exec { 'reload_systemd_for_confluence':
+      command     => 'systemctl daemon-reload',
+      refreshonly => true,
+    }
+
+    if $confluence::manage_service {
+      service { 'confluence':
+        ensure  => 'running',
+        enable  => true,
+        require => [ Class['confluence::config'], Systemd::Service['confluence'], ],
+      }
+    }
+  }
+
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -36,14 +36,16 @@ class confluence::service (
 
   if $confluence::systemd_module == 'eyp' {
     systemd::service { 'confluence':
-      description => 'Confluence Team Collaboration Software',
-      after       => 'network.target',
-      user        => $confluence::user,
-      group       => $confluence::group,
-      forking     => true,
-      execstart   => "${confluence::webappdir}/bin/start-confluence.sh",
-      execstop    => "${confluence::webappdir}/bin/stop-confluence.sh",
-      env_vars    => [ "\"JAVA_HOME=${confluence::javahome}\"" ],
+      description  => 'Confluence Team Collaboration Software',
+      after        => 'network.target',
+      user         => $confluence::user,
+      group        => $confluence::group,
+      forking      => true,
+      execstart    => "${confluence::webappdir}/bin/start-confluence.sh",
+      execstop     => "${confluence::webappdir}/bin/stop-confluence.sh",
+      env_vars     => [ "\"JAVA_HOME=${confluence::javahome}\"" ],
+      limit_nofile => $confluence::service_nofile,
+      limit_nproc  => $confluence::service_nproc,
     }
 
     if $confluence::manage_service {

--- a/templates/confluence.service.erb
+++ b/templates/confluence.service.erb
@@ -8,6 +8,12 @@ User=<%= scope.lookupvar('confluence::user') %>
 Environment="JAVA_HOME=<%= scope.lookupvar('confluence::javahome') %>"
 ExecStart=<%= scope.lookupvar('confluence::webappdir') %>/bin/start-confluence.sh
 ExecStop=<%= scope.lookupvar('confluence::webappdir') %>/bin/stop-confluence.sh
+<% if scope.lookupvar('confluence::service_nofile') != nil -%>
+LimitNOFILE=<%= scope.lookupvar('confluence::service_nofile') %>
+<% end %>
+<% if scope.lookupvar('confluence::service_nproc') != nil -%>
+LimitNPROC=<%= scope.lookupvar('confluence::service_nproc') %>
+<% end -%>
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
#### Pull Request (PR) description

This PR adds a new parameter called 'systemd_module' which allows a user to choose which systemd module to use to manage the Confluence service.  It defaults to 'camptocamp' and also supports 'eyp'.