### PR TITLE
Don't create confluence.cfg.xml

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -101,12 +101,6 @@ class confluence::install {
     group  => $confluence::group,
     owner  => $confluence::user,
   }
-  -> file { "${confluence::homedir}/confluence.cfg.xml":
-    ensure => file,
-    owner  => $confluence::user,
-    group  => $confluence::group,
-    mode   => '0640',
-  }
   -> exec { "chown_${confluence::webappdir}":
     command     => "/bin/chown -R ${confluence::user}:${confluence::group} ${confluence::webappdir}",
     refreshonly => true,


### PR DESCRIPTION
Confluence (at least as of 6.14.1, maybe it worked in the past) won't start with blank confluence.cfg.xml. Since the presence of this file prevents a fresh confluence install from starting, I propose it simply not be created.