### PR TITLE
use service_provider fact to detect systemd, support Debian 9

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,45 +4,27 @@
 #
 class confluence::params {
 
-  case $facts['os']['family'] {
-    /RedHat/: {
-      if $facts['os']['release']['major'] == '7' {
-        $service_file_location = '/usr/lib/systemd/system/confluence.service'
-        $service_file_template = 'confluence/confluence.service.erb'
-        $service_lockfile      = '/var/lock/subsys/confluence'
-        $refresh_systemd       = true
-      } elsif $facts['os']['release']['major'] == '6' {
-        $service_file_location = '/etc/init.d/confluence'
-        $service_file_template = 'confluence/confluence.initscript.erb'
-        $service_lockfile      = '/var/lock/subsys/confluence'
-        $refresh_systemd       = false
-      } else {
-        fail("Only osfamily ${facts['os']['family']} 6 and 7 and supported")
+  case $facts['service_provider'] {
+    'systemd': {
+      case $facts['os']['family'] {
+        /RedHat/: {
+          $service_file_location = '/usr/lib/systemd/system/confluence.service'
+          $service_file_template = 'confluence/confluence.service.erb'
+          $refresh_systemd       = true
+        }
+        /Debian/: {
+          $service_file_location = '/etc/systemd/system/confluence.service'
+          $service_file_template = 'confluence/confluence.service.erb'
+          $refresh_systemd       = true
+        }
+        default: { fail('Only osfamily Debian and Redhat are supported for systemd') }
       }
     }
-    /Debian/: {
-      case $facts['os']['name'] {
-        /Ubuntu/: {
-          if $facts['service_provider'] == 'systemd' {
-            $service_file_location   = '/etc/systemd/system/confluence.service'
-            $service_file_template   = 'confluence/confluence.service.erb'
-            $service_lockfile        = '/var/lock/subsys/confluence'
-            $refresh_systemd         = true
-          } else {
-            $service_file_location   = '/etc/init.d/confluence'
-            $service_file_template   = 'confluence/confluence.initscript.erb'
-            $service_lockfile        = '/var/lock/confluence'
-            $refresh_systemd         = false
-          }
-        }
-        default: {
-          $service_file_location   = '/etc/init.d/confluence'
-          $service_file_template   = 'confluence/confluence.initscript.erb'
-          $service_lockfile        = '/var/lock/confluence'
-          $refresh_systemd         = false
-        }
-      }
+    default: {
+      $service_file_location = '/etc/init.d/confluence'
+      $service_file_template = 'confluence/confluence.initscript.erb'
+      $refresh_systemd       = false
     }
-    default: { fail('Only osfamily Debian and Redhat are supported') }
   }
+
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -5,7 +5,6 @@
 class confluence::service (
   $service_file_location = $confluence::params::service_file_location,
   $service_file_template = $confluence::params::service_file_template,
-  $service_lockfile      = $confluence::params::service_lockfile,
   $refresh_systemd       = $confluence::params::refresh_systemd,
 ) {
 

--- a/metadata.json
+++ b/metadata.json
@@ -54,6 +54,12 @@
         "16.04",
         "18.04"
       ]
+    },
+    {
+      "operatingsystem": "Debian",
+      "operatingsystemrelease": [
+        "9"
+      ]
     }
   ]
 }

--- a/spec/classes/confluence_params_spec.rb
+++ b/spec/classes/confluence_params_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper.rb'
+
+describe 'confluence' do
+  describe 'confluence::params' do
+    on_supported_os.each do |os, fs_facts|
+      context "on #{os}" do
+        let :facts do
+          fs_facts
+        end
+
+        let(:params) do
+          {
+            javahome: '/opt/java',
+            version: '5.5.6'
+          }
+        end
+
+        context 'service_provider is systemd' do
+          let :facts do
+            fs_facts.merge(service_provider: 'systemd')
+          end
+
+          case os
+          when %r{^centos}, %r{^redhat}
+            it { is_expected.to contain_file('/usr/lib/systemd/system/confluence.service') }
+          when %r{^ubuntu}, %r{^debian}
+            it { is_expected.to contain_file('/etc/systemd/system/confluence.service') }
+          end
+
+          it { is_expected.to compile.with_all_deps }
+        end
+
+        context 'service_provider is not systemd' do
+          it { is_expected.to contain_file('/etc/init.d/confluence') }
+          it { is_expected.to compile.with_all_deps }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Use service_provider fact to detect systemd for both Debian and RedHat os families. Explicitly (added in metadata.json) adds support for Debian 9, and implicitly (should work without further modification) supports future versions of Ubuntu and RedHat/CentOS.

Fixes #158

