### PR TITLE
moving end statement to allow values from java_opts to be applied to …

### DIFF
--- a/templates/setenv.sh.erb
+++ b/templates/setenv.sh.erb
@@ -70,13 +70,13 @@ echo "--------------------------------------------------------------------------
 JVM_MINIMUM_MEMORY="<%= scope['confluence::jvm_xms'] %>"
 JVM_MAXIMUM_MEMORY="<%= scope['confluence::jvm_xmx'] %>"
 JVM_PERMGEN_MEMORY="<%= scope['confluence::jvm_permgen'] %>"
+<%- end -%>
 
 #
 # Additional JAVA_OPTS
 #
 JAVA_OPTS="<%= scope['confluence::java_opts'] %> $JAVA_OPTS"
 export JAVA_OPTS
-<%- end -%>
 <%- if version[0] >= 5 -%>
 
 # Set the JVM arguments used to start Confluence. For a description of the options, see
@@ -115,4 +115,3 @@ CATALINA_OPTS="<%= catalina_opts %> ${CATALINA_OPTS}"
 
 export CATALINA_OPTS
 <%- end # if version[0] >= 5 -%>
-


### PR DESCRIPTION
…setenv.sh file. These values are needed if you are running confluence behind proxies and to allow the synchrony functionality.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
The PR fixes the passing of java_opt values in order to populate things like proxy servers or values for supporting synchrony.
If these values are not passed, things like the Market place will NOT work because the application is not aware of the proxy it should be sending traffic to.
Also for synchrony to work, you need to pass the following values:
`JAVA_OPTS="-Dsynchrony.proxy.enabled=true`

These values should not be bound to the version of confluence.

These values are currently in use in about 3 different Confluence installations of different versions of the application.

#### This Pull Request (PR) fixes the following issues
No specific issues (reported) but it does allow the following to work:
Atlassian market place
Synchrony 
