### PR TITLE
Add support for Java11 (logging options)

### DIFF
--- a/templates/setenv.sh.erb
+++ b/templates/setenv.sh.erb
@@ -81,6 +81,13 @@ export JAVA_OPTS
 
 # Set the JVM arguments used to start Confluence. For a description of the options, see
 # http://www.oracle.com/technetwork/java/javase/tech/vmoptions-jsp-140102.html
+
+<%-   if version[0] >= 7 # 7.x.x or higher -%>
+<%-     if version[1] >= 1 # 7.1.x or higher -%>
+CATALINA_OPTS="-XX:+IgnoreUnrecognizedVMOptions ${CATALINA_OPTS}"
+CATALINA_OPTS="-Xlog:gc+age=debug:file=$LOGBASEABS/logs/gc-`date +%F_%H-%M-%S`.log::filecount=5,filesize=2M ${CATALINA_OPTS}"
+<%-     end -%>
+<%-   end -%>
 CATALINA_OPTS="-XX:-PrintGCDetails -XX:+PrintGCDateStamps -XX:-PrintTenuringDistribution ${CATALINA_OPTS}"
 CATALINA_OPTS="-Xloggc:$LOGBASEABS/logs/gc-`date +%F_%H-%M-%S`.log -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=5 -XX:GCLogFileSize=2M ${CATALINA_OPTS}"
 CATALINA_OPTS="-XX:G1ReservePercent=20 ${CATALINA_OPTS}"
@@ -88,15 +95,19 @@ CATALINA_OPTS="-Djava.awt.headless=true ${CATALINA_OPTS}"
 CATALINA_OPTS="-Datlassian.plugins.enable.wait=300 ${CATALINA_OPTS}"
 CATALINA_OPTS="-Xms<%= scope['confluence::jvm_xms'] %> -Xmx<%= scope['confluence::jvm_xmx'] %> -XX:+UseG1GC ${CATALINA_OPTS}"
 <%-   if version[0] >= 6 # 6.x.x or higher -%>
-<%-     if version[1] >= 1 # 6.1.x or higher -%>
+<%-     if version[0] >= 7 or version[1] >= 1 # 6.1.x or higher -%>
 CATALINA_OPTS="-Dsynchrony.enable.xhr.fallback=true ${CATALINA_OPTS}"
 <%-     end -%>
 CATALINA_OPTS="-Dorg.apache.tomcat.websocket.DEFAULT_BUFFER_SIZE=32768 ${CATALINA_OPTS}"
-<%-     if version[1] >= 1 # 6.1.x or higher -%>
+<%-     if version[0] >= 7 or version[1] >= 1 # 6.1.x or higher -%>
 CATALINA_OPTS="${START_CONFLUENCE_JAVA_OPTS} ${CATALINA_OPTS}"
 <%-     end -%>
 CATALINA_OPTS="-Dconfluence.context.path=${CONFLUENCE_CONTEXT_PATH} ${CATALINA_OPTS}"
-<%-     if version[1] >= 8 # 6.8.x or higher -%>
+<%-     if version[0] >= 7 and version[1] >= 1 # 7.1.x or higher -%>
+CATALINA_OPTS="-Djava.locale.providers=JRE,SPI,CLDR ${CATALINA_OPTS}"
+CATALINA_OPTS="-Djdk.tls.server.protocols=TLSv1.1,TLSv1.2 -Djdk.tls.client.protocols=TLSv1.1,TLSv1.2 ${CATALINA_OPTS}"
+<%-     end -%>
+<%-     if version[0] >= 7 or version[1] >= 8 # 6.8.x or higher -%>
 CATALINA_OPTS="-XX:ReservedCodeCacheSize=256m -XX:+UseCodeCacheFlushing ${CATALINA_OPTS}"
 <%-     end -%>
 <%-   end -%>


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Add support for Java 11 (Confluence added support in v7.1)

No nice way to do it from provided java home, so set with a boolean flag.

#### This Pull Request (PR) fixes the following issues
Replaces GC logging commands which are no longer recognised with like-for-like Xlog options
