### PR TITLE
If manage_user=false, don't depend on the User resource

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -63,8 +63,10 @@ class confluence::install {
         before  => File[$confluence::homedir],
         require => [
           File[$confluence::installdir],
-          User[$confluence::user],
           File[$confluence::webappdir] ],
+      }
+      if $confluence::manage_user {
+        User[$confluence::user] -> Staging::Extract[$file]
       }
     }
     'archive': {
@@ -87,8 +89,10 @@ class confluence::install {
         require         => [
           File[$confluence::installdir],
           File[$confluence::webappdir],
-          User[$confluence::user],
         ],
+      }
+      if $confluence::manage_user {
+        User[$confluence::user] -> Archive["/tmp/${file}"]
       }
     }
     default: {
@@ -104,6 +108,8 @@ class confluence::install {
   -> exec { "chown_${confluence::webappdir}":
     command     => "/bin/chown -R ${confluence::user}:${confluence::group} ${confluence::webappdir}",
     refreshonly => true,
-    subscribe   => User[$confluence::user],
+  }
+  if $confluence::manage_user{
+    User[$confluence::user] ~> Exec["chown_${confluence::webappdir}"]
   }
 }

--- a/spec/classes/confluence_config_spec.rb
+++ b/spec/classes/confluence_config_spec.rb
@@ -159,6 +159,36 @@ describe 'confluence' do
               with_content(%r{CATALINA_OPTS=\"-Dconfluence.cluster.node.name=myhostname \${CATALINA_OPTS}\"})
           end
         end
+
+        context 'manage_user set to true' do
+          let(:params) do
+            {
+              version: '6.12.0',
+              javahome: '/opt/java',
+              manage_user: true
+            }
+          end
+
+          it do
+            is_expected.to compile.with_all_deps
+            is_expected.to contain_user('confluence').that_notifies('Exec[chown_/opt/confluence/atlassian-confluence-6.12.0]')
+          end
+        end
+
+        context 'manage_user set to false' do
+          let(:params) do
+            {
+              version: '6.12.0',
+              javahome: '/opt/java',
+              manage_user: false
+            }
+          end
+
+          it do
+            is_expected.to compile.with_all_deps
+            is_expected.not_to contain_user('confluence')
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
#### Pull Request (PR) description
If ``manage_user=false``, don't depend on the existence of a User[] resource.

We are forced to rely on a user supplied by LDAP, which is not created (and cannot be edited by) a User[] resource. 

The only negative I can think of to this PR is if somebody is defining a User resource elsewhere, setting manage_user to false, and then expecting resources within this module to be subscribed to it. It seems unlikely but possible.

For reference, we are following the same methodology with BitBucket, where it behaves as expected if ``manage_usr_grp`` is set to false. 

