### PR TITLE
Fully deprecate puppet/staging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,6 @@ These should not affect the functionality of the module.
 
 - drop support for deprecated puppet/staging module
 
-**Breaking changes:**
-
 ## [v4.0.0](https://github.com/voxpupuli/puppet-confluence/tree/v4.0.0) (2020-05-09)
 
 [Full Changelog](https://github.com/voxpupuli/puppet-confluence/compare/v3.2.0...v4.0.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 Each new release typically also includes the latest modulesync defaults.
 These should not affect the functionality of the module.
 
+## v5.0.0 (2020-07-xx)
+
+[Full Changelog]
+
+**Breaking changes:**
+
+- drop support for deprecated puppet/staging module
+
+**Breaking changes:**
+
 ## [v4.0.0](https://github.com/voxpupuli/puppet-confluence/tree/v4.0.0) (2020-05-09)
 
 [Full Changelog](https://github.com/voxpupuli/puppet-confluence/compare/v3.2.0...v4.0.0)

--- a/README.md
+++ b/README.md
@@ -313,27 +313,18 @@ Defaults to '<https://www.atlassian.com/software/confluence/downloads/binary>'
 ##### `checksum`
 
 The md5 checksum of the archive file. Only supported with
-`deploy_module => archive`. Defaults to 'undef'.
 
 #### `proxy_server`
 
 Specify a proxy server, with port number if needed. ie: https://example.com:8080.
-Only supported with `deploy_module => archive` (the default).  Defaults to 'undef'.
 
 #### `proxy_type`
 
 Proxy server type (none|http|https|ftp)
-Only supported with `deploy_module => archive` (the default).  Defaults to 'undef'.
 
 ##### `manage_service`
 
 Should puppet manage this service? Default: true
-
-##### `deploy_module`
-
-Module to use for downloading and extracting archive file. Supports
-puppet-archive and puppet-staging. Defaults to 'archive'. Archive supports md5
-hash checking and Staging supports S3 buckets.
 
 ##### `stop_confluence`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -27,8 +27,6 @@ class confluence (
   # Misc Settings
   $download_url                                                  = 'https://www.atlassian.com/software/confluence/downloads/binary',
   $checksum                                                      = undef,
-  # Choose whether to use puppet-staging, or puppet-archive
-  $deploy_module                                                 = 'archive',
   # Manage confluence server
   $manage_service                                                = true,
   # Tomcat Tunables

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -46,54 +46,27 @@ class confluence::install {
     }
   }
 
-  case $confluence::deploy_module {
-    'staging': {
-      require staging
-      staging::file { $file:
-        source  => "${confluence::download_url}/${file}",
-        timeout => 1800,
-      }
-      -> staging::extract { $file:
-        target  => $confluence::webappdir,
-        creates => "${confluence::webappdir}/conf",
-        strip   => 1,
-        user    => $confluence::user,
-        group   => $confluence::group,
-        notify  => Exec["chown_${confluence::webappdir}"],
-        before  => File[$confluence::homedir],
-        require => [
-          File[$confluence::installdir],
-          User[$confluence::user],
-          File[$confluence::webappdir] ],
-      }
-    }
-    'archive': {
-      archive { "/tmp/${file}":
-        ensure          => present,
-        extract         => true,
-        extract_command => 'tar xfz %s --strip-components=1',
-        extract_path    => $confluence::webappdir,
-        source          => "${confluence::download_url}/${file}",
-        creates         => "${confluence::webappdir}/conf",
-        cleanup         => true,
-        checksum_verify => $confluence::checksum_verify,
-        checksum_type   => 'md5',
-        checksum        => $confluence::checksum,
-        user            => $confluence::user,
-        group           => $confluence::group,
-        proxy_server    => $confluence::proxy_server,
-        proxy_type      => $confluence::proxy_type,
-        before          => File[$confluence::homedir],
-        require         => [
-          File[$confluence::installdir],
-          File[$confluence::webappdir],
-          User[$confluence::user],
-        ],
-      }
-    }
-    default: {
-      fail('deploy_module parameter must equal "archive" or "staging"')
-    }
+  archive { "/tmp/${file}":
+    ensure          => present,
+    extract         => true,
+    extract_command => 'tar xfz %s --strip-components=1',
+    extract_path    => $confluence::webappdir,
+    source          => "${confluence::download_url}/${file}",
+    creates         => "${confluence::webappdir}/conf",
+    cleanup         => true,
+    checksum_verify => $confluence::checksum_verify,
+    checksum_type   => 'md5',
+    checksum        => $confluence::checksum,
+    user            => $confluence::user,
+    group           => $confluence::group,
+    proxy_server    => $confluence::proxy_server,
+    proxy_type      => $confluence::proxy_type,
+    before          => File[$confluence::homedir],
+    require         => [
+      File[$confluence::installdir],
+      File[$confluence::webappdir],
+      User[$confluence::user],
+    ],
   }
 
   file { [ $confluence::homedir, "${confluence::homedir}/logs" ]:

--- a/metadata.json
+++ b/metadata.json
@@ -18,10 +18,6 @@
       "version_requirement": ">= 1.0.0 < 5.0.0"
     },
     {
-      "name": "puppet/staging",
-      "version_requirement": ">= 2.0.1 < 4.0.0"
-    },
-    {
       "name": "puppet/mysql_java_connector",
       "version_requirement": ">= 3.0.2 < 4.0.0"
     },


### PR DESCRIPTION
This PR completely removes the puppet/staging module dependancy

- Remove the ability to use it via $deploy_module
- Remove dependancy from metadata.json
- Updated README and CHANGELOG

This will break things for anyone using deploy_module => 'staging', so a major version bump is proposed. 