### PR TITLE
Allow defining additional Tomcat connectors

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -11,6 +11,8 @@ class confluence::config(
   $manage_server_xml   = $confluence::manage_server_xml,
   $context_path        = $confluence::context_path,
   $ajp                 = $confluence::ajp,
+  # Additional connectors in server.xml
+  Confluence::Tomcat_connectors $tomcat_additional_connectors = $confluence::tomcat_additional_connectors,
 ) {
 
   File {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -44,6 +44,8 @@ class confluence (
   $context_path                                                  = '',
   # Options for the AJP connector
   Hash $ajp                                                      = {},
+  # Additional connectors in server.xml
+  Confluence::Tomcat_connectors $tomcat_additional_connectors    = {},
   # Command to stop confluence in preparation to updgrade. This is configurable
   # incase the confluence service is managed outside of puppet. eg: using the
   # puppetlabs-corosync module: 'crm resource stop confluence && sleep 15'

--- a/spec/classes/confluence_config_spec.rb
+++ b/spec/classes/confluence_config_spec.rb
@@ -127,6 +127,54 @@ describe 'confluence' do
           end
         end
 
+        context 'tomcat additional connectors' do
+          let(:params) do
+            {
+              version: '5.5.6',
+              javahome: '/opt/java',
+              manage_server_xml: 'template',
+              tomcat_additional_connectors: {
+                8081 => {
+                  'URIEncoding' => 'UTF-8',
+                  'connectionTimeout' => '20000',
+                  'protocol' => 'HTTP/1.1',
+                  'proxyName' => 'foo.example.com',
+                  'proxyPort' => '8123',
+                  'secure' => true,
+                  'scheme' => 'https'
+                },
+                8082 => {
+                  'URIEncoding' => 'UTF-8',
+                  'connectionTimeout' => '20000',
+                  'protocol' => 'HTTP/1.1',
+                  'proxyName' => 'bar.example.com',
+                  'proxyPort' => '8124',
+                  'scheme' => 'http'
+                }
+              }
+            }
+          end
+
+          it do
+            is_expected.to contain_file('/opt/confluence/atlassian-confluence-5.5.6/conf/server.xml').
+              with_content(%r{<Connector port="8081"}).
+              with_content(%r{connectionTimeout="20000"}).
+              with_content(%r{protocol="HTTP/1\.1"}).
+              with_content(%r{proxyName="foo\.example\.com"}).
+              with_content(%r{proxyPort="8123"}).
+              with_content(%r{scheme="https"}).
+              with_content(%r{secure="true"}).
+              with_content(%r{URIEncoding="UTF-8"}).
+              with_content(%r{<Connector port="8082"}).
+              with_content(%r{connectionTimeout="20000"}).
+              with_content(%r{protocol="HTTP/1\.1"}).
+              with_content(%r{proxyName="bar\.example\.com"}).
+              with_content(%r{proxyPort="8124"}).
+              with_content(%r{scheme="http"}).
+              with_content(%r{URIEncoding="UTF-8"})
+          end
+        end
+
         context 'catalina_opts set to a string' do
           let(:params) do
             {

--- a/spec/type_aliases/tomcat_attributes_spec.rb
+++ b/spec/type_aliases/tomcat_attributes_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+
+describe 'Confluence::Tomcat_attributes' do
+  describe 'valid attributes' do
+    [
+      { 'URIEncoding' => 'UTF-8' },
+      { 'secure' => true },
+      { 'proxyPort' => 8443 },
+      {
+        'URIEncoding' => 'UTF-8',
+        'connectionTimeout' => '20000',
+        'protocol' => 'HTTP/1.1',
+        'proxyName' => 'foo.example.com',
+        'proxyPort' => '8123',
+        'secure' => true,
+        'scheme' => 'https'
+      },
+      {}
+    ].each do |value|
+      describe value.inspect do
+        it { is_expected.to allow_value(value) }
+      end
+    end
+  end
+
+  describe 'invalid attributes' do
+    context 'with garbage inputs' do
+      [
+        { %w[foo blah] => 'bar' },
+        { true => 'false' },
+        { 'proxyPort' => %w[8443 1234] },
+        { 'schema' => { 'https' => 'false' } },
+        true,
+        false,
+        :keyword,
+        nil,
+        %w[yes no],
+        '',
+        'ネット',
+        '55555',
+        '0x123',
+        'yess',
+        'nooo'
+      ].each do |value|
+        describe value.inspect do
+          it { is_expected.not_to allow_value(value) }
+        end
+      end
+    end
+  end
+end

--- a/spec/type_aliases/tomcat_connectors_spec.rb
+++ b/spec/type_aliases/tomcat_connectors_spec.rb
@@ -1,0 +1,80 @@
+require 'spec_helper'
+
+describe 'Confluence::Tomcat_connectors' do
+  describe 'valid connector specifications' do
+    [
+      {
+        8081 => {
+          'URIEncoding' => 'UTF-8',
+          'connectionTimeout' => '20000',
+          'protocol' => 'HTTP/1.1',
+          'proxyName' => 'foo.example.com',
+          'proxyPort' => '80',
+          'secure' => false,
+          'scheme' => 'http'
+        },
+        8443 => {
+          'URIEncoding' => 'UTF-8',
+          'connectionTimeout' => '20000',
+          'protocol' => 'HTTP/1.1',
+          'proxyName' => 'foo.example.com',
+          'proxyPort' => '443',
+          'secure' => true,
+          'scheme' => 'https'
+        }
+      }
+    ].each do |value|
+      describe value.inspect do
+        it { is_expected.to allow_value(value) }
+      end
+    end
+  end
+
+  describe 'invalid connector specifications' do
+    context 'with garbage inputs' do
+      [
+        {
+          '8081' => {
+            'URIEncoding' => 'UTF-8',
+            'connectionTimeout' => '20000',
+            'protocol' => 'HTTP/1.1',
+            'proxyName' => 'foo.example.com',
+            'proxyPort' => '80',
+            'secure' => false,
+            'scheme' => 'http'
+          }
+        },
+        {
+          1023 => {
+            'URIEncoding' => 'UTF-8',
+            'connectionTimeout' => '20000',
+            'protocol' => 'HTTP/1.1',
+            'proxyName' => 'foo.example.com',
+            'proxyPort' => '80',
+            'secure' => false,
+            'scheme' => 'http'
+          }
+        },
+        { %w[foo blah] => 'bar' },
+        { true => 'false' },
+        { 'proxyPort' => %w[8443 1234] },
+        { 'schema' => { 'https' => 'false' } },
+        true,
+        false,
+        :keyword,
+        nil,
+        %w[yes no],
+        '',
+        'ネット',
+        '55555',
+        '0x123',
+        'yess',
+        'nooo'
+      ].each do |value|
+        describe value.inspect do
+          it { is_expected.not_to allow_value(value) }
+        end
+      end
+    end
+  end
+end

--- a/templates/server.xml.erb
+++ b/templates/server.xml.erb
@@ -16,7 +16,7 @@
 <%   @tomcat_proxy.sort.each do |key,value| -%>
                    <%= key %>=<%= "\"#{value}\"" %>
 <%   end -%>
-<% end -%> 
+<% end -%>
 />
 
 <% if @ajp and ! @ajp.empty? -%>
@@ -25,6 +25,15 @@
                    <%= key %> = <%= "\"#{value}\"" %>
 <%   end -%>
         />
+<% end -%>
+<% if @tomcat_additional_connectors and ! @tomcat_additional_connectors.empty? -%>
+<% @tomcat_additional_connectors.sort.map do |port, attrs| -%>
+        <Connector port="<%= port -%>"
+<% attrs.sort.map do |key, value| -%>
+                   <%= key -%>="<%= value -%>"
+<% end -%>
+                   />
+<% end -%>
 <% end -%>
 
         <Engine name="Standalone" defaultHost="localhost" debug="0">

--- a/types/tomcat_attributes.pp
+++ b/types/tomcat_attributes.pp
@@ -1,0 +1,1 @@
+type Confluence::Tomcat_attributes = Hash[String[1], Scalar]

--- a/types/tomcat_connectors.pp
+++ b/types/tomcat_connectors.pp
@@ -1,0 +1,1 @@
+type Confluence::Tomcat_connectors = Hash[Stdlib::Port::Unprivileged, Confluence::Tomcat_attributes]


### PR DESCRIPTION
Add a new, optional class parameter
`confluence::tomcat_additional_connectors` whose value is a well-formed,
complex hash as described by the new type aliases
`Confluence::Tomcat_connectors` and `Confluence::Tomcat_attributes`.
Each hash key represents a port number, and the key's value is a hash
that describes the connector's attributes and their values.

Useful for defining additional HTTP ports through which to access
Confluence.  A typical use case is when Jira and Confluence run behind a
reverse proxy and application links between Jira and Confluence must be
set up.  Then it is often better to allow Jira and Confluence to
communicate directly instead of through the reverse proxy, but this
requires a Tomcat connector that is configured for direct access instead
of reverse proxy access (`proxyName`, `proxyPort`, etc). Described here:
https://confluence.atlassian.com/kb/how-to-create-an-unproxied-application-link-719095740.html

Contains spec tests, documentation and examples.

A very similar PR was submitted to puppet-jira in https://github.com/voxpupuli/puppet-jira/pull/316