### PR TITLE
made systemd daemon reload dependent on puppet version; Drop Puppet 5 support

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,7 +3,6 @@ fixtures:
     archive: "https://github.com/voxpupuli/puppet-archive.git"
     staging: "https://github.com/voxpupuli/puppet-staging.git"
     stdlib:  "https://github.com/puppetlabs/puppetlabs-stdlib.git"
-    systemd: "https://github.com/camptocamp/puppet-systemd.git"
     mysql_java_connector: "https://github.com/voxpupuli/puppet-mysql_java_connector.git"
     augeas_core:
       repo: https://github.com/puppetlabs/puppetlabs-augeas_core.git

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,12 +9,10 @@ class confluence::params {
         /RedHat/: {
           $service_file_location = '/usr/lib/systemd/system/confluence.service'
           $service_file_template = 'confluence/confluence.service.erb'
-          $refresh_systemd       = true
         }
         /Debian/: {
           $service_file_location = '/etc/systemd/system/confluence.service'
           $service_file_template = 'confluence/confluence.service.erb'
-          $refresh_systemd       = true
         }
         default: { fail('Only osfamily Debian and Redhat are supported for systemd') }
       }
@@ -22,7 +20,6 @@ class confluence::params {
     default: {
       $service_file_location = '/etc/init.d/confluence'
       $service_file_template = 'confluence/confluence.initscript.erb'
-      $refresh_systemd       = false
     }
   }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -15,7 +15,10 @@ class confluence::service (
     service { 'confluence':
       ensure  => 'running',
       enable  => true,
-      require => [Class['confluence::config'], File[$service_file_location], ],
+      require => [
+        Class['confluence::config'],
+        File[$service_file_location],
+      ],
     }
   }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -5,15 +5,7 @@
 class confluence::service (
   $service_file_location = $confluence::params::service_file_location,
   $service_file_template = $confluence::params::service_file_template,
-  $refresh_systemd       = $confluence::params::refresh_systemd,
 ) {
-  # Since Puppet 6.1.0 it's no longer needed to run daemon-reload manually when restarting a service. That means it's possible to drop this code. Since Puppet 4 & 5 are now EOL, this should be ok.
-  # https://github.com/camptocamp/puppet-systemd/pull/171
-  if($refresh_systemd and versioncmp($facts['puppetversion'], '6.1.0') < 0) {
-    include systemd::systemctl::daemon_reload
-    File[$service_file_location] ~> Class['systemd::systemctl::daemon_reload']
-  }
-
   file { $service_file_location:
     content => template($service_file_template),
     mode    => '0755',

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -7,26 +7,23 @@ class confluence::service (
   $service_file_template = $confluence::params::service_file_template,
   $refresh_systemd       = $confluence::params::refresh_systemd,
 ) {
-  if($refresh_systemd) {
+  # Since Puppet 6.1.0 it's no longer needed to run daemon-reload manually when restarting a service. That means it's possible to drop this code. Since Puppet 4 & 5 are now EOL, this should be ok.
+  # https://github.com/camptocamp/puppet-systemd/pull/171
+  if($refresh_systemd and versioncmp($facts['puppetversion'], '6.1.0') < 0) {
     include systemd::systemctl::daemon_reload
+    File[$service_file_location] ~> Class['systemd::systemctl::daemon_reload']
   }
 
   file { $service_file_location:
     content => template($service_file_template),
     mode    => '0755',
-    notify  => [
-      $refresh_systemd ? {
-        true    => Class['systemd::systemctl::daemon_reload'],
-        default => undef
-      }
-    ],
   }
 
   if $confluence::manage_service {
     service { 'confluence':
       ensure  => 'running',
       enable  => true,
-      require => [Class['confluence::config'], File[$service_file_location],],
+      require => [Class['confluence::config'], File[$service_file_location], ],
     }
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -10,10 +10,6 @@
   "description": "Atlassian confluence",
   "dependencies": [
     {
-      "name": "camptocamp/systemd",
-      "version_requirement": ">= 1.0.0 < 3.0.0"
-    },
-    {
       "name": "puppet/archive",
       "version_requirement": ">= 1.0.0 < 5.0.0"
     },
@@ -33,7 +29,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 5.5.8 < 7.0.0"
+      "version_requirement": ">= 6.1.0 < 7.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
#### Pull Request (PR) description
The latest version of the systemd module has dropped support for the deamon_reload. It was a workaround, but is not needed anymore since puppet 6.1.
Added a check to avoid calling the reload on puppet > 6.1

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
