### PR TITLE
If manage_user=false, don't depend on the User resource (obsoletes #198)

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -60,8 +60,11 @@ class confluence::install {
         before  => File[$confluence::homedir],
         require => [
           File[$confluence::installdir],
-          User[$confluence::user],
-        File[$confluence::webappdir]],
+          File[$confluence::webappdir],
+        ],
+      }
+      if $confluence::manage_user {
+        User[$confluence::user] -> Staging::Extract[$file]
       }
     }
     'archive': {
@@ -84,8 +87,10 @@ class confluence::install {
         require         => [
           File[$confluence::installdir],
           File[$confluence::webappdir],
-          User[$confluence::user],
         ],
+      }
+      if $confluence::manage_user {
+        User[$confluence::user] -> Archive["/tmp/${file}"]
       }
     }
     default: {
@@ -101,6 +106,8 @@ class confluence::install {
   -> exec { "chown_${confluence::webappdir}":
     command     => "/bin/chown -R ${confluence::user}:${confluence::group} ${confluence::webappdir}",
     refreshonly => true,
-    subscribe   => User[$confluence::user],
+  }
+  if $confluence::manage_user{
+    User[$confluence::user] ~> Exec["chown_${confluence::webappdir}"]
   }
 }

--- a/spec/classes/confluence_config_spec.rb
+++ b/spec/classes/confluence_config_spec.rb
@@ -207,6 +207,36 @@ describe 'confluence' do
               with_content(%r{CATALINA_OPTS=\"-Dconfluence.cluster.node.name=myhostname \${CATALINA_OPTS}\"})
           end
         end
+
+        context 'manage_user set to true' do
+          let(:params) do
+            {
+              version: '6.12.0',
+              javahome: '/opt/java',
+              manage_user: true
+            }
+          end
+
+          it do
+            is_expected.to compile.with_all_deps
+            is_expected.to contain_user('confluence').that_notifies('Exec[chown_/opt/confluence/atlassian-confluence-6.12.0]')
+          end
+        end
+
+        context 'manage_user set to false' do
+          let(:params) do
+            {
+              version: '6.12.0',
+              javahome: '/opt/java',
+              manage_user: false
+            }
+          end
+
+          it do
+            is_expected.to compile.with_all_deps
+            is_expected.not_to contain_user('confluence')
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
#### Pull Request (PR) description

Update of PR #198 rebased against master

When `$manage_user=false`, don't permit any resources to `require => User[$confluence::user]` since it does not exist in the catalog.