### PR TITLE
Integrated java parameters added or changed in Confluence 7.12

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,9 +6,11 @@ class confluence (
 
   # JVM Settings
   $javahome                                                      = undef,
+  Enum['openjdk-11', 'oracle-jdk-1.8', 'custom'] $jvm_type       = 'openjdk-11',
   $jvm_xms                                                       = '256m',
   $jvm_xmx                                                       = '1024m',
   $jvm_permgen                                                   = '256m',
+  Boolean $big_instances_opts                                    = false,
   $java_opts                                                     = '',
   Variant[String,Array[String]] $catalina_opts                   = '',
   # Confluence Settings
@@ -50,6 +52,7 @@ class confluence (
   # incase the confluence service is managed outside of puppet. eg: using the
   # puppetlabs-corosync module: 'crm resource stop confluence && sleep 15'
   $stop_confluence                                               = 'service confluence stop && sleep 15',
+  Boolean $upgrade_recovery_file                                 = true,
   # Enable SingleSignOn via Crowd
   $enable_sso                                                    = false,
   $application_name                                              = 'crowd',

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -107,7 +107,7 @@ class confluence::install {
     command     => "/bin/chown -R ${confluence::user}:${confluence::group} ${confluence::webappdir}",
     refreshonly => true,
   }
-  if $confluence::manage_user{
+  if $confluence::manage_user {
     User[$confluence::user] ~> Exec["chown_${confluence::webappdir}"]
   }
 }

--- a/spec/classes/confluence_config_spec.rb
+++ b/spec/classes/confluence_config_spec.rb
@@ -208,6 +208,53 @@ describe 'confluence' do
           end
         end
 
+        context 'default java 11 specific option' do
+          let(:params) do
+            {
+              version: '7.12.0',
+              javahome: '/opt/java'
+            }
+          end
+
+          it do
+            is_expected.to compile.with_all_deps
+            is_expected.to contain_file('/opt/confluence/atlassian-confluence-7.12.0/bin/setenv.sh').
+              with_content(%r{CATALINA_OPTS=\"-XX:\+ExplicitGCInvokesConcurrent -XX:\+PrintGCDateStamps \${CATALINA_OPTS}\"})
+          end
+        end
+
+        context 'default java 11 big instance option' do
+          let(:params) do
+            {
+              version: '7.12.0',
+              javahome: '/opt/java',
+              big_instances_opts: true
+            }
+          end
+
+          it do
+            is_expected.to compile.with_all_deps
+            is_expected.to contain_file('/opt/confluence/atlassian-confluence-7.12.0/bin/setenv.sh').
+              with_content(%r{CATALINA_OPTS=\"-XX:ReservedCodeCacheSize=384m \${CATALINA_OPTS}\"})
+          end
+        end
+
+        context 'java 8 specific option' do
+          let(:params) do
+            {
+              version: '7.12.0',
+              javahome: '/opt/java',
+              jvm_type: 'oracle-jdk-1.8'
+            }
+          end
+
+          it do
+            is_expected.to compile.with_all_deps
+            is_expected.to contain_file('/opt/confluence/atlassian-confluence-7.12.0/bin/setenv.sh').
+              with_content(%r{CATALINA_OPTS=\"-XX:-PrintGCDetails -XX:\+PrintGCDateStamps -XX:-PrintTenuringDistribution \${CATALINA_OPTS}\"})
+          end
+        end
+
         context 'manage_user set to true' do
           let(:params) do
             {

--- a/templates/setenv.sh.erb
+++ b/templates/setenv.sh.erb
@@ -88,7 +88,11 @@ CATALINA_OPTS="-XX:+IgnoreUnrecognizedVMOptions ${CATALINA_OPTS}"
 CATALINA_OPTS="-Xlog:gc+age=debug:file=$LOGBASEABS/logs/gc-`date +%F_%H-%M-%S`.log::filecount=5,filesize=2M ${CATALINA_OPTS}"
 <%-     end -%>
 <%-   end -%>
+<%- if scope.lookupvar('confluence::jvm_type') == 'openjdk-11' -%>
+CATALINA_OPTS="-XX:+ExplicitGCInvokesConcurrent -XX:+PrintGCDateStamps ${CATALINA_OPTS}"
+<%- elsif scope.lookupvar('confluence::jvm_type')  == 'oracle-jdk-1.8' -%>
 CATALINA_OPTS="-XX:-PrintGCDetails -XX:+PrintGCDateStamps -XX:-PrintTenuringDistribution ${CATALINA_OPTS}"
+<%- end -%>
 CATALINA_OPTS="-Xloggc:$LOGBASEABS/logs/gc-`date +%F_%H-%M-%S`.log -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=5 -XX:GCLogFileSize=2M ${CATALINA_OPTS}"
 CATALINA_OPTS="-XX:G1ReservePercent=20 ${CATALINA_OPTS}"
 CATALINA_OPTS="-Djava.awt.headless=true ${CATALINA_OPTS}"
@@ -105,15 +109,23 @@ CATALINA_OPTS="${START_CONFLUENCE_JAVA_OPTS} ${CATALINA_OPTS}"
 CATALINA_OPTS="-Dconfluence.context.path=${CONFLUENCE_CONTEXT_PATH} ${CATALINA_OPTS}"
 <%-     if version[0] >= 7 and version[1] >= 1 # 7.1.x or higher -%>
 CATALINA_OPTS="-Djava.locale.providers=JRE,SPI,CLDR ${CATALINA_OPTS}"
-CATALINA_OPTS="-Djdk.tls.server.protocols=TLSv1.1,TLSv1.2 -Djdk.tls.client.protocols=TLSv1.1,TLSv1.2 ${CATALINA_OPTS}"
 <%-     end -%>
 <%-     if version[0] >= 7 or version[1] >= 8 # 6.8.x or higher -%>
 CATALINA_OPTS="-XX:ReservedCodeCacheSize=256m -XX:+UseCodeCacheFlushing ${CATALINA_OPTS}"
+<%- if scope.lookupvar('confluence::big_instances_opts') == true and scope.lookupvar('confluence::jvm_type')  == 'openjdk-11' -%>
+# these will overwrite same options set earlier
+CATALINA_OPTS="-XX:ReservedCodeCacheSize=384m ${CATALINA_OPTS}"
+CATALINA_OPTS="-XX:+PrintTenuringDistribution ${CATALINA_OPTS}"
+CATALINA_OPTS="-XX:+PrintGCDetails -XX:+PrintGCTimeStamps ${CATALINA_OPTS}"
+<%- end -%>
 <%-     end -%>
 <%-   end -%>
 <%-   if version[0] == 5 and version[1] <= 7 # 5.7.x and below -%>
 CATALINA_OPTS="-XX:MaxPermSize=<%= scope['confluence::jvm_permgen'] %> ${CATALINA_OPTS}"
 <%-   end -%>
+<%- if @upgrade_recovery_file == false -%>
+CATALINA_OPTS="-Dconfluence.upgrade.recovery.file.enabled=false ${CATALINA_OPTS}"
+<%- end -%>
 <%- catalina_opts = scope['confluence::catalina_opts'] -%>
 <%-   if catalina_opts.is_a?(Array) # add each option as its own line -%>
 <%-     catalina_opts.each do |opt| -%>


### PR DESCRIPTION
#### Pull Request (PR) description
This integrates the setenv.sh java parameter changes of Confluence 7.12, see this: https://confluence.atlassian.com/doc/confluence-7-12-upgrade-notes-1044092469.html#Confluence7.12UpgradeNotes-setenvfileimprovements
It allows to set parameters depending on the java version, similar like it was done in the puppet-jira module. Also it allows to set options for bigger instances as recommended on the same article linked above.