### PR TITLE
Add tomcat_redirect_port variable to customise redirectPort in server.xml

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -3,14 +3,15 @@
 # Install confluence, See README.md for more.
 #
 class confluence::config (
-  $tomcat_port         = $confluence::tomcat_port,
-  $tomcat_max_threads  = $confluence::tomcat_max_threads,
-  $tomcat_accept_count = $confluence::tomcat_accept_count,
-  $tomcat_proxy        = $confluence::tomcat_proxy,
-  $tomcat_extras       = $confluence::tomcat_extras,
-  $manage_server_xml   = $confluence::manage_server_xml,
-  $context_path        = $confluence::context_path,
-  $ajp                 = $confluence::ajp,
+  $tomcat_port          = $confluence::tomcat_port,
+  $tomcat_redirect_port = $confluence::tomcat_redirect_port,
+  $tomcat_max_threads   = $confluence::tomcat_max_threads,
+  $tomcat_accept_count  = $confluence::tomcat_accept_count,
+  $tomcat_proxy         = $confluence::tomcat_proxy,
+  $tomcat_extras        = $confluence::tomcat_extras,
+  $manage_server_xml    = $confluence::manage_server_xml,
+  $context_path         = $confluence::context_path,
+  $ajp                  = $confluence::ajp,
   # Additional connectors in server.xml
   Confluence::Tomcat_connectors $tomcat_additional_connectors = $confluence::tomcat_additional_connectors,
 ) {
@@ -32,11 +33,12 @@ class confluence::config (
   }
 
   if $manage_server_xml == 'augeas' {
-    $_tomcat_max_threads  = { maxThreads  => $tomcat_max_threads }
-    $_tomcat_accept_count = { acceptCount => $tomcat_accept_count }
-    $_tomcat_port         = { port        => $tomcat_port }
+    $_tomcat_max_threads   = { maxThreads   => $tomcat_max_threads }
+    $_tomcat_accept_count  = { acceptCount  => $tomcat_accept_count }
+    $_tomcat_port          = { port         => $tomcat_port }
+    $_tomcat_redirect_port = { redirectPort => $tomcat_redirect_port }
 
-    $parameters = merge($_tomcat_max_threads, $_tomcat_accept_count, $tomcat_proxy, $tomcat_extras, $_tomcat_port )
+    $parameters = merge($_tomcat_max_threads, $_tomcat_accept_count, $tomcat_proxy, $tomcat_extras, $_tomcat_port, $_tomcat_redirect_port )
 
     if versioncmp($facts['augeas']['version'], '1.0.0') < 0 {
       fail('This module requires Augeas >= 1.0.0')

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -35,6 +35,7 @@ class confluence (
   # Should we use augeas to manage server.xml or a template file
   Enum['augeas', 'template'] $manage_server_xml                  = 'augeas',
   $tomcat_port                                                   = 8090,
+  $tomcat_redirect_port                                          = 8443,
   $tomcat_max_threads                                            = 150,
   $tomcat_accept_count                                           = 100,
   # Reverse https proxy setting for tomcat

--- a/spec/classes/confluence_config_spec.rb
+++ b/spec/classes/confluence_config_spec.rb
@@ -42,6 +42,7 @@ describe 'confluence' do
               manage_server_xml: 'template',
               context_path: '/confluence1',
               tomcat_port: 8089,
+              tomcat_redirect_port: 443,
               tomcat_max_threads: 999,
               tomcat_accept_count: 999,
               tomcat_proxy: {
@@ -57,6 +58,7 @@ describe 'confluence' do
           it do
             is_expected.to contain_file('/opt/confluence/atlassian-confluence-5.5.6/conf/server.xml').
               with_content(%r{port="8089"}).
+              with_content(%r{redirectPort="443"}).
               with_content(%r{maxThreads="999"}).
               with_content(%r{acceptCount="999"}).
               with_content(%r{scheme="https"}).

--- a/templates/server.xml.erb
+++ b/templates/server.xml.erb
@@ -5,7 +5,7 @@
                    minProcessors="5"
                    maxProcessors="75"
                    enableLookups="false"
-                   redirectPort="8443"
+                   redirectPort="<%= @tomcat_redirect_port %>"
                    debug="0"
                    connectionTimeout="20000"
                    useURIValidationHack="false"


### PR DESCRIPTION
#### Pull Request (PR) description
This PR allows a user to define a port to redirect to on the default connector using a variable, similarly to tomcat_port. In my case I needed to use manage_server_xml in template mode so I could define an additional connector, which doesn't work with tomcat_extras so I couldn't define it there.

Arguably everything about the default connector should be customisable in server xml template mode, so we could add those if needed also.

Also, somewhat unrelated but tomcat_additional_connectors does not work with the augeaus mode, unless I'm missing something.

#### This Pull Request (PR) fixes the following issues
N/A