### PR TITLE
Add variable to configure maxHttpHeaderSize attribute

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -3,15 +3,16 @@
 # Install confluence, See README.md for more.
 #
 class confluence::config (
-  $tomcat_port          = $confluence::tomcat_port,
-  $tomcat_redirect_port = $confluence::tomcat_redirect_port,
-  $tomcat_max_threads   = $confluence::tomcat_max_threads,
-  $tomcat_accept_count  = $confluence::tomcat_accept_count,
-  $tomcat_proxy         = $confluence::tomcat_proxy,
-  $tomcat_extras        = $confluence::tomcat_extras,
-  $manage_server_xml    = $confluence::manage_server_xml,
-  $context_path         = $confluence::context_path,
-  $ajp                  = $confluence::ajp,
+  $tomcat_port                 = $confluence::tomcat_port,
+  $tomcat_redirect_port        = $confluence::tomcat_redirect_port,
+  $tomcat_max_threads          = $confluence::tomcat_max_threads,
+  $tomcat_accept_count         = $confluence::tomcat_accept_count,
+  $tomcat_max_http_header_size = $confluence::tomcat_max_http_header_size,
+  $tomcat_proxy                = $confluence::tomcat_proxy,
+  $tomcat_extras               = $confluence::tomcat_extras,
+  $manage_server_xml           = $confluence::manage_server_xml,
+  $context_path                = $confluence::context_path,
+  $ajp                         = $confluence::ajp,
   # Additional connectors in server.xml
   Confluence::Tomcat_connectors $tomcat_additional_connectors = $confluence::tomcat_additional_connectors,
 ) {
@@ -33,12 +34,13 @@ class confluence::config (
   }
 
   if $manage_server_xml == 'augeas' {
-    $_tomcat_max_threads   = { maxThreads   => $tomcat_max_threads }
-    $_tomcat_accept_count  = { acceptCount  => $tomcat_accept_count }
-    $_tomcat_port          = { port         => $tomcat_port }
-    $_tomcat_redirect_port = { redirectPort => $tomcat_redirect_port }
+    $_tomcat_max_threads          = { maxThreads        => $tomcat_max_threads }
+    $_tomcat_max_http_header_size = { maxHttpHeaderSize => $tomcat_max_http_header_size }
+    $_tomcat_accept_count         = { acceptCount       => $tomcat_accept_count }
+    $_tomcat_port                 = { port              => $tomcat_port }
+    $_tomcat_redirect_port        = { redirectPort      => $tomcat_redirect_port }
 
-    $parameters = merge($_tomcat_max_threads, $_tomcat_accept_count, $tomcat_proxy, $tomcat_extras, $_tomcat_port, $_tomcat_redirect_port )
+    $parameters = merge($_tomcat_max_threads, $_tomcat_max_http_header_size, $_tomcat_accept_count, $tomcat_proxy, $tomcat_extras, $_tomcat_port, $_tomcat_redirect_port )
 
     if versioncmp($facts['augeas']['version'], '1.0.0') < 0 {
       fail('This module requires Augeas >= 1.0.0')

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -39,6 +39,7 @@ class confluence (
   $tomcat_port                                                   = 8090,
   $tomcat_redirect_port                                          = 8443,
   $tomcat_max_threads                                            = 150,
+  $tomcat_max_http_header_size                                   = 8192,
   $tomcat_accept_count                                           = 100,
   # Reverse https proxy setting for tomcat
   Hash $tomcat_proxy                                             = {},

--- a/spec/classes/confluence_config_spec.rb
+++ b/spec/classes/confluence_config_spec.rb
@@ -43,6 +43,7 @@ describe 'confluence' do
               context_path: '/confluence1',
               tomcat_port: 8089,
               tomcat_redirect_port: 443,
+              tomcat_max_http_header_size: 8192,
               tomcat_max_threads: 999,
               tomcat_accept_count: 999,
               tomcat_proxy: {
@@ -59,6 +60,7 @@ describe 'confluence' do
             is_expected.to contain_file('/opt/confluence/atlassian-confluence-5.5.6/conf/server.xml').
               with_content(%r{port="8089"}).
               with_content(%r{redirectPort="443"}).
+              with_content(%r{maxHttpHeaderSize="8192"}).
               with_content(%r{maxThreads="999"}).
               with_content(%r{acceptCount="999"}).
               with_content(%r{scheme="https"}).

--- a/templates/server.xml.erb
+++ b/templates/server.xml.erb
@@ -11,6 +11,7 @@
                    useURIValidationHack="false"
                    URIEncoding="UTF-8"
               	   maxThreads="<%= @tomcat_max_threads %>"
+                   maxHttpHeaderSize="<%= @tomcat_max_http_header_size %>"
                    acceptCount="<%= @tomcat_accept_count %>"
 <% if @tomcat_proxy -%>
 <%   @tomcat_proxy.sort.each do |key,value| -%>


### PR DESCRIPTION
#### Pull Request (PR) description
Add variable to be able to configure tomcat's maxHttpHeaderSize attribute.

Default is set to 8192 (from https://tomcat.apache.org/tomcat-9.0-doc/config/http.html `maxHttpHeaderSize: If not specified, this attribute is set to 8192 (8 KB).`)
